### PR TITLE
feat: get monetary value not applied with dynamic weight

### DIFF
--- a/core/contracts/composed_stream_template.kf
+++ b/core/contracts/composed_stream_template.kf
@@ -161,7 +161,7 @@ procedure get_raw_index(
 // if the last known value is not available, it will not emit the record, making it a sparse table
 procedure get_record_filled($date_from text, $date_to text, $frozen_at int) private view returns table(
     date_value text,
-    value_with_weight decimal(36,18), // value * weight
+    value_with_weight decimal(36,18), // value * dynamic weight
     // we also return the weight, so we can calculate the total weight for a date
     weight decimal(36,18)
 ) {
@@ -170,7 +170,6 @@ procedure get_record_filled($date_from text, $date_to text, $frozen_at int) priv
 
     // Initialize taxonomy variables
     $taxonomy_count int := 0;
-    $taxonomy_weight_list decimal(36,18)[];
     $last_values decimal(36,18)[];
     $child_data_providers text[];
     $child_stream_id text[];
@@ -179,7 +178,6 @@ procedure get_record_filled($date_from text, $date_to text, $frozen_at int) priv
     for $row in SELECT * FROM describe_taxonomies(true) {
         $taxonomy_count := $taxonomy_count + 1;
         $base_taxonomy_list := array_append($base_taxonomy_list, $taxonomy_count);
-        $taxonomy_weight_list := array_append($taxonomy_weight_list, $row.weight);
         $last_values := array_append($last_values, null::decimal(36,18));
         $child_data_providers := array_append($child_data_providers, $row.child_data_provider);
         $child_stream_id := array_append($child_stream_id, $row.child_stream_id);
@@ -195,8 +193,12 @@ procedure get_record_filled($date_from text, $date_to text, $frozen_at int) priv
    // - better manipulation of tables as objects, then we could modify a table to
    //   fill forward without needing to return immediately on each loop
 
+    // Fetch raw records and emit values with dynamic weights
     for $row_raw in SELECT * FROM get_raw_record($date_from, $date_to, $frozen_at, $child_data_providers, $child_stream_id) ORDER BY date_value, taxonomy_index {
         $current_date := $row_raw.date_value;
+
+        // Fetch the dynamic weight based on the current date
+        $dynamic_weight decimal(36,18) := get_dynamic_weight($child_stream_id[$row_raw.taxonomy_index], $current_date);
 
         // Emit filled values for previous date if date has changed
         if $current_date != $prev_date {
@@ -204,12 +206,14 @@ procedure get_record_filled($date_from text, $date_to text, $frozen_at int) priv
                 for $unemitted_taxonomy in $unemitted_taxonomies_for_date {
                     // TODO: remove this when we have slices or include if we have just index assignment
                     // if $unemitted_taxonomy is distinct from null {
-                        if $last_values[$unemitted_taxonomy] is distinct from null {
-                            return next $prev_date, $last_values[$unemitted_taxonomy] * $taxonomy_weight_list[$unemitted_taxonomy], $taxonomy_weight_list[$unemitted_taxonomy];
-                        }
-                    // }
+
+                    if $last_values[$unemitted_taxonomy] is distinct from null {
+                        // Use the stored dynamic weight from the previous date
+                        $dynamic_weight_prev := get_dynamic_weight($child_stream_id[$unemitted_taxonomy], $prev_date);
+                        return next $prev_date, $last_values[$unemitted_taxonomy] * $dynamic_weight_prev, $dynamic_weight_prev;
+                    }
                 }
-                // we're moving to a new date, let's clear the unemitted_taxonomies_for_date list and the removed_elements_count
+                // Clear unemitted taxonomies for the new date
                 $unemitted_taxonomies_for_date := $base_taxonomy_list;
                 $removed_elements_count := 0;
             }
@@ -217,12 +221,14 @@ procedure get_record_filled($date_from text, $date_to text, $frozen_at int) priv
 
         // TODO: uncomment when we have index assignment
         // $last_values[$row_raw.taxonomy_index] := $row_raw.value;
+
+        // Update the last values for the current date
         $last_values := array_update_element($last_values, $row_raw.taxonomy_index, $row_raw.value);
 
-        // Emit current value
-        return next $current_date, $row_raw.value * $taxonomy_weight_list[$row_raw.taxonomy_index], $taxonomy_weight_list[$row_raw.taxonomy_index];
+        // Emit current value with the dynamic weight
+        return next $current_date, $row_raw.value * $dynamic_weight, $dynamic_weight;
 
-        // let's remove the emitted taxonomy from the unemitted_taxonomies_for_date list
+        // Remove emitted taxonomy from the unemitted list
         // we need to subtract the removed_elements_count because the array is shrinking
         // TODO: we can improve it when we either can remove elements, or with array element assignment
         $unemitted_taxonomies_for_date := remove_array_element($unemitted_taxonomies_for_date, $row_raw.taxonomy_index - $removed_elements_count);
@@ -238,7 +244,9 @@ procedure get_record_filled($date_from text, $date_to text, $frozen_at int) priv
         if $taxonomy_count > 0 {
             for $unemitted_taxonomy2 in $unemitted_taxonomies_for_date {
                 if $last_values[$unemitted_taxonomy2] is distinct from null {
-                    return next $prev_date, $last_values[$unemitted_taxonomy2] * $taxonomy_weight_list[$unemitted_taxonomy2], $taxonomy_weight_list[$unemitted_taxonomy2];
+                    // Fetch the correct dynamic weight for the last date
+                    $dynamic_weight_last := get_dynamic_weight($child_stream_id[$unemitted_taxonomy2], $prev_date);
+                    return next $prev_date, $last_values[$unemitted_taxonomy2] * $dynamic_weight_last, $dynamic_weight_last;
                 }
             }
         }
@@ -1075,5 +1083,16 @@ procedure get_dynamic_weight($stream_id text, $date_value text) private view ret
     ORDER BY start_date DESC
     LIMIT 1 {
         return $row.weight;
+    }
+
+    // If no weight is found, we return the earliest weight available, this to ensure that we always have a weight
+    // for the given date even if it's before the first weight's start_date
+    // Would be better if COALESCE was supported
+    for $row2 in SELECT weight
+    FROM taxonomies
+    WHERE child_stream_id = $stream_id
+    ORDER BY start_date ASC
+    LIMIT 1 {
+        return $row2.weight;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

added dynamic weight on get_record

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/679
related: https://github.com/truflation/tsn/pull/681

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tested with go test.
streams like CPI_US, is fine too.

```
kwil-cli database call -a=get_record date_from:2024-06-27 date_to:2024-07-03 -n=st18a5fdeb0a96e5618f69688f5f13e5
| date_value |          value          |
+------------+-------------------------+
| 2024-06-27 | 9684.116884017534331033 |
| 2024-06-28 | 9711.007477903537024902 |
| 2024-06-30 | 9710.953264182164887689 |
| 2024-07-01 | 9232.775457604299654400 | <- notice a drop here because rebalancing
| 2024-07-02 | 9185.715622041443203000 |
| 2024-07-03 | 9229.345405358254667400 |

kwil-cli database call -a=get_record date_from:2024-06-27 date_to:2024-07-03 -n=stf389ad7681059ca7750dda907735b2
| date_value |         value          |
+------------+------------------------+
| 2024-06-27 | 536.618748029000000000 |
| 2024-06-28 | 536.866274777000000000 |
| 2024-07-01 | 536.841170343000000000 |
| 2024-07-02 | 538.438691881000000000 |
| 2024-07-03 | 538.606971521000000000 |

kwil-cli database call -a=get_record date_from:2024-06-27 date_to:2024-07-03 -n=st3a73954246460ddeee5ccf594676cf
| date_value |          value          |
+------------+-------------------------+
| 2024-06-27 | 6218.130919434627750000 |
| 2024-06-28 | 6217.488860528931750000 |
| 2024-06-29 | 6217.488860528931750000 |
| 2024-06-30 | 6217.274745751815750000 |
| 2024-07-01 | 6527.040012764273000000 |
| 2024-07-02 | 6528.236937734174000000 |
| 2024-07-03 | 6528.529920307802000000 |
```