### PR TITLE
feat: update Value field type to float64 in InsertRecordUnixInput

### DIFF
--- a/core/contractsapi/primitive_stream.go
+++ b/core/contractsapi/primitive_stream.go
@@ -99,7 +99,7 @@ func (p *PrimitiveStream) InsertRecordsUnix(ctx context.Context, inputs []types.
 
 		args = append(args, []any{
 			dateStr,
-			strconv.Itoa(input.Value),
+			fmt.Sprintf("%f", input.Value),
 		})
 	}
 

--- a/core/types/primitive_stream.go
+++ b/core/types/primitive_stream.go
@@ -14,7 +14,7 @@ type InsertRecordInput struct {
 
 type InsertRecordUnixInput struct {
 	DateValue int
-	Value     int
+	Value     float64
 }
 
 type IPrimitiveStream interface {

--- a/tests/integration/get_all_streams_test.go
+++ b/tests/integration/get_all_streams_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"context"
+	"testing"
+
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	"github.com/kwilteam/kwil-db/core/types/client"
@@ -11,7 +13,6 @@ import (
 	"github.com/trufnetwork/sdk-go/core/types"
 	"github.com/trufnetwork/sdk-go/core/util"
 	"github.com/trufnetwork/sdk-go/tests/integration/assets"
-	"testing"
 )
 
 func TestListAllStreams(t *testing.T) {
@@ -87,7 +88,9 @@ func TestListAllStreams(t *testing.T) {
 	// Check non-initalized stream
 	initializedStreams, err := tnClient.GetAllInitializedStreams(ctx, types.GetAllStreamsInput{})
 	assertNoErrorOrFail(t, err, "Failed to list all streams")
-	assert.Empty(t, initializedStreams, "It should be empty as no stream is initialized")
+	
+	// Count the number of initialized streams before the test
+	initialInitializedStreamsCount := len(initializedStreams)
 
 	// initialize the stream primitiveStreamId
 	primitiveStream, err := tnClient.LoadStream(types.StreamLocator{
@@ -113,5 +116,5 @@ func TestListAllStreams(t *testing.T) {
 	// Check initialized stream
 	initializedStreams, err = tnClient.GetAllInitializedStreams(ctx, types.GetAllStreamsInput{})
 	assertNoErrorOrFail(t, err, "Failed to list all streams")
-	assert.Equal(t, 2, len(initializedStreams), "It should be 2 as 2 streams are initialized")
+	assert.Equal(t, initialInitializedStreamsCount+2, len(initializedStreams), "It should be 2 as 2 streams are initialized")
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- New type was based on a previous version where integer was used, leaving out decimals. This PR addresses this correctly

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #67 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tests passed