### PR TITLE
feat(tests): integration tests for rapid insertions

### DIFF
--- a/tests/integration/batch_operations_test.go
+++ b/tests/integration/batch_operations_test.go
@@ -1,0 +1,243 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kwilteam/kwil-db/core/crypto"
+	"github.com/kwilteam/kwil-db/core/crypto/auth"
+	"github.com/kwilteam/kwil-db/core/types/transactions"
+	"github.com/stretchr/testify/assert"
+	"github.com/trufnetwork/sdk-go/core/tnclient"
+	"github.com/trufnetwork/sdk-go/core/types"
+	"github.com/trufnetwork/sdk-go/core/util"
+)
+
+func TestBatchOperations(t *testing.T) {
+	ctx := context.Background()
+
+	// Parse the private key for authentication
+	pk, err := crypto.Secp256k1PrivateKeyFromHex(TestPrivateKey)
+	assertNoErrorOrFail(t, err, "Failed to parse private key")
+
+	// Create a signer using the parsed private key
+	signer := &auth.EthPersonalSigner{Key: *pk}
+
+	// Initialize the TN client with the signer
+	tnClient, err := tnclient.NewClient(ctx, TestKwilProvider, tnclient.WithSigner(signer))
+	assertNoErrorOrFail(t, err, "Failed to create client")
+
+	t.Run("TestSequentialSmallBatches", func(t *testing.T) {
+		streamId := util.GenerateStreamId("test-sequential-small")
+		streamLocator := tnClient.OwnStreamLocator(streamId)
+
+		// Set up cleanup
+		t.Cleanup(func() {
+			destroyResult, err := tnClient.DestroyStream(ctx, streamId)
+			assertNoErrorOrFail(t, err, "Failed to destroy stream")
+			waitTxToBeMinedWithSuccess(t, ctx, tnClient, destroyResult)
+		})
+
+		// Deploy and initialize stream
+		deployTxHash, err := tnClient.DeployStream(ctx, streamId, types.StreamTypePrimitiveUnix)
+		assertNoErrorOrFail(t, err, "Failed to deploy stream")
+		waitTxToBeMinedWithSuccess(t, ctx, tnClient, deployTxHash)
+
+		deployedStream, err := tnClient.LoadPrimitiveStream(streamLocator)
+		assertNoErrorOrFail(t, err, "Failed to load stream")
+
+		txHashInit, err := deployedStream.InitializeStream(ctx)
+		assertNoErrorOrFail(t, err, "Failed to initialize stream")
+		waitTxToBeMinedWithSuccess(t, ctx, tnClient, txHashInit)
+
+		const numBatches = 500
+		const recordsPerBatch = 5
+		baseTimestamp := 1672531200 // Start from 2023-01-01
+
+		// Insert multiple batches without waiting
+		txHashes := make([]transactions.TxHash, 0, numBatches)
+		startTime := time.Now()
+
+		for batch := 0; batch < numBatches; batch++ {
+			records := make([]types.InsertRecordUnixInput, recordsPerBatch)
+			for i := 0; i < recordsPerBatch; i++ {
+				records[i] = types.InsertRecordUnixInput{
+					DateValue: baseTimestamp + (batch * 86400) + (i * 3600),
+					Value:     float64(batch*100 + i),
+				}
+			}
+
+			txHash, err := deployedStream.InsertRecordsUnix(ctx, records)
+			assertNoErrorOrFail(t, err, "Failed to insert batch")
+			txHashes = append(txHashes, txHash)
+		}
+
+		insertionDuration := time.Since(startTime)
+		fmt.Printf("[Small Batches] All insertions completed in %v (avg %v per batch, %v per record)\n",
+			insertionDuration,
+			insertionDuration/time.Duration(numBatches),
+			insertionDuration/time.Duration(numBatches*recordsPerBatch))
+
+		// Wait for all transactions after sending them all
+		waitStart := time.Now()
+		for _, txHash := range txHashes {
+			waitTxToBeMinedWithSuccess(t, ctx, tnClient, txHash)
+		}
+		waitDuration := time.Since(waitStart)
+		fmt.Printf("[Small Batches] All transactions confirmed in %v\n", waitDuration)
+
+		// Verify total number of records
+		totalRecords := numBatches * recordsPerBatch
+		dateFrom := baseTimestamp
+		dateTo := baseTimestamp + (numBatches * 86400)
+
+		records, err := deployedStream.GetRecordUnix(ctx, types.GetRecordUnixInput{
+			DateFrom: &dateFrom,
+			DateTo:   &dateTo,
+		})
+		assertNoErrorOrFail(t, err, "Failed to query records")
+		assert.Equal(t, totalRecords, len(records), "Unexpected number of records")
+	})
+
+	t.Run("TestSequentialLargeBatches", func(t *testing.T) {
+		streamId := util.GenerateStreamId("test-sequential-large")
+		streamLocator := tnClient.OwnStreamLocator(streamId)
+
+		// Set up cleanup
+		t.Cleanup(func() {
+			destroyResult, err := tnClient.DestroyStream(ctx, streamId)
+			assertNoErrorOrFail(t, err, "Failed to destroy stream")
+			waitTxToBeMinedWithSuccess(t, ctx, tnClient, destroyResult)
+		})
+
+		// Deploy and initialize stream
+		deployTxHash, err := tnClient.DeployStream(ctx, streamId, types.StreamTypePrimitiveUnix)
+		assertNoErrorOrFail(t, err, "Failed to deploy stream")
+		waitTxToBeMinedWithSuccess(t, ctx, tnClient, deployTxHash)
+
+		deployedStream, err := tnClient.LoadPrimitiveStream(streamLocator)
+		assertNoErrorOrFail(t, err, "Failed to load stream")
+
+		txHashInit, err := deployedStream.InitializeStream(ctx)
+		assertNoErrorOrFail(t, err, "Failed to initialize stream")
+		waitTxToBeMinedWithSuccess(t, ctx, tnClient, txHashInit)
+
+		const numBatches = 500
+		const recordsPerBatch = 100
+		baseTimestamp := 1672531200 // Start from 2023-01-01
+
+		// Insert multiple batches without waiting
+		txHashes := make([]transactions.TxHash, 0, numBatches)
+		startTime := time.Now()
+
+		for batch := 0; batch < numBatches; batch++ {
+			records := make([]types.InsertRecordUnixInput, recordsPerBatch)
+			for i := 0; i < recordsPerBatch; i++ {
+				records[i] = types.InsertRecordUnixInput{
+					DateValue: baseTimestamp + (batch * 86400) + (i * 300), // 5-minute intervals
+					Value:     float64(batch*1000 + i),
+				}
+			}
+
+			txHash, err := deployedStream.InsertRecordsUnix(ctx, records)
+			assertNoErrorOrFail(t, err, "Failed to insert batch")
+			txHashes = append(txHashes, txHash)
+		}
+
+		insertionDuration := time.Since(startTime)
+		fmt.Printf("[Large Batches] All insertions completed in %v (avg %v per batch, %v per record)\n",
+			insertionDuration,
+			insertionDuration/time.Duration(numBatches),
+			insertionDuration/time.Duration(numBatches*recordsPerBatch))
+
+		// Wait for all transactions after sending them all
+		waitStart := time.Now()
+		for _, txHash := range txHashes {
+			waitTxToBeMinedWithSuccess(t, ctx, tnClient, txHash)
+		}
+		waitDuration := time.Since(waitStart)
+		fmt.Printf("[Large Batches] All transactions confirmed in %v\n", waitDuration)
+
+		// Verify total number of records
+		totalRecords := numBatches * recordsPerBatch
+		dateFrom := baseTimestamp
+		dateTo := baseTimestamp + (numBatches * 86400)
+
+		records, err := deployedStream.GetRecordUnix(ctx, types.GetRecordUnixInput{
+			DateFrom: &dateFrom,
+			DateTo:   &dateTo,
+		})
+		assertNoErrorOrFail(t, err, "Failed to query records")
+		assert.Equal(t, totalRecords, len(records), "Unexpected number of records")
+	})
+
+	t.Run("TestRapidSingleRecordInserts", func(t *testing.T) {
+		streamId := util.GenerateStreamId("test-rapid-singles")
+		streamLocator := tnClient.OwnStreamLocator(streamId)
+
+		// Set up cleanup
+		t.Cleanup(func() {
+			destroyResult, err := tnClient.DestroyStream(ctx, streamId)
+			assertNoErrorOrFail(t, err, "Failed to destroy stream")
+			waitTxToBeMinedWithSuccess(t, ctx, tnClient, destroyResult)
+		})
+
+		// Deploy and initialize stream
+		deployTxHash, err := tnClient.DeployStream(ctx, streamId, types.StreamTypePrimitiveUnix)
+		assertNoErrorOrFail(t, err, "Failed to deploy stream")
+		waitTxToBeMinedWithSuccess(t, ctx, tnClient, deployTxHash)
+
+		deployedStream, err := tnClient.LoadPrimitiveStream(streamLocator)
+		assertNoErrorOrFail(t, err, "Failed to load stream")
+
+		txHashInit, err := deployedStream.InitializeStream(ctx)
+		assertNoErrorOrFail(t, err, "Failed to initialize stream")
+		waitTxToBeMinedWithSuccess(t, ctx, tnClient, txHashInit)
+
+		const numRecords = 500
+		baseTimestamp := 1672531200 // Start from 2023-01-01
+
+		// Rapidly insert individual records without waiting
+		txHashes := make([]transactions.TxHash, 0, numRecords)
+		startTime := time.Now()
+
+		for i := 0; i < numRecords; i++ {
+			records := []types.InsertRecordUnixInput{
+				{
+					DateValue: baseTimestamp + (i * 3600),
+					Value:     float64(i),
+				},
+			}
+
+			txHash, err := deployedStream.InsertRecordsUnix(ctx, records)
+			assertNoErrorOrFail(t, err, "Failed to insert record")
+			txHashes = append(txHashes, txHash)
+		}
+
+		insertionDuration := time.Since(startTime)
+		fmt.Printf("[Single Records] All insertions completed in %v (avg %v per record)\n",
+			insertionDuration,
+			insertionDuration/time.Duration(numRecords))
+
+		// Wait for all transactions after sending them all
+		waitStart := time.Now()
+		for _, txHash := range txHashes {
+			waitTxToBeMinedWithSuccess(t, ctx, tnClient, txHash)
+		}
+		waitDuration := time.Since(waitStart)
+		fmt.Printf("[Single Records] All transactions confirmed in %v\n", waitDuration)
+
+		// Verify all records were inserted
+		dateFrom := baseTimestamp
+		dateTo := baseTimestamp + (numRecords * 3600)
+
+		records, err := deployedStream.GetRecordUnix(ctx, types.GetRecordUnixInput{
+			DateFrom: &dateFrom,
+			DateTo:   &dateTo,
+		})
+		assertNoErrorOrFail(t, err, "Failed to query records")
+		assert.Equal(t, numRecords, len(records), "Unexpected number of records")
+	})
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- benchmark our insert capabilities. however note that this is a unreal baseline where the node is on the same machine as the inserter

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #70 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

run tests

## Results

```
go test -v ./tests/integration -run TestBatchOperations -count=1
=== RUN   TestBatchOperations
=== RUN   TestBatchOperations/TestSequentialSmallBatches
[Small Batches] All insertions completed in 4.350266812s (avg 8.700533ms per batch, 1.740106ms per record)
[Small Batches] All transactions confirmed in 9.165253162s
=== RUN   TestBatchOperations/TestSequentialLargeBatches
[Large Batches] All insertions completed in 5.315716126s (avg 10.631432ms per batch, 106.314µs per record)
[Large Batches] All transactions confirmed in 2m1.424877338s
=== RUN   TestBatchOperations/TestRapidSingleRecordInserts
[Single Records] All insertions completed in 4.031131257s (avg 8.062262ms per record)
[Single Records] All transactions confirmed in 5.166030486s
--- PASS: TestBatchOperations (192.69s)
    --- PASS: TestBatchOperations/TestSequentialSmallBatches (25.80s)
    --- PASS: TestBatchOperations/TestSequentialLargeBatches (143.53s)
    --- PASS: TestBatchOperations/TestRapidSingleRecordInserts (23.35s)
PASS
ok      github.com/trufnetwork/sdk-go/tests/integration 192.732s
```

in theory, on these conditions, we can insert 500 records in 5 seconds at most