### PR TITLE
feat: support transaction options (primitive)

### DIFF
--- a/core/contractsapi/primitive_stream.go
+++ b/core/contractsapi/primitive_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kwilteam/kwil-db/core/types/client"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 	"github.com/pkg/errors"
 	"github.com/trufnetwork/sdk-go/core/types"
@@ -57,16 +58,16 @@ func (p *PrimitiveStream) checkValidPrimitiveStream(ctx context.Context) error {
 	return nil
 }
 
-func (p *PrimitiveStream) checkedExecute(ctx context.Context, method string, args [][]any) (transactions.TxHash, error) {
+func (p *PrimitiveStream) checkedExecute(ctx context.Context, method string, args [][]any, opts ...client.TxOpt) (transactions.TxHash, error) {
 	err := p.checkValidPrimitiveStream(ctx)
 	if err != nil {
 		return transactions.TxHash{}, errors.WithStack(err)
 	}
 
-	return p._client.Execute(ctx, p.DBID, method, args)
+	return p._client.Execute(ctx, p.DBID, method, args, opts...)
 }
 
-func (p *PrimitiveStream) InsertRecords(ctx context.Context, inputs []types.InsertRecordInput) (transactions.TxHash, error) {
+func (p *PrimitiveStream) InsertRecords(ctx context.Context, inputs []types.InsertRecordInput, opts ...client.TxOpt) (transactions.TxHash, error) {
 	err := p.checkValidPrimitiveStream(ctx)
 	if err != nil {
 		return transactions.TxHash{}, errors.WithStack(err)
@@ -83,10 +84,10 @@ func (p *PrimitiveStream) InsertRecords(ctx context.Context, inputs []types.Inse
 		})
 	}
 
-	return p.checkedExecute(ctx, "insert_record", args)
+	return p.checkedExecute(ctx, "insert_record", args, opts...)
 }
 
-func (p *PrimitiveStream) InsertRecordsUnix(ctx context.Context, inputs []types.InsertRecordUnixInput) (transactions.TxHash, error) {
+func (p *PrimitiveStream) InsertRecordsUnix(ctx context.Context, inputs []types.InsertRecordUnixInput, opts ...client.TxOpt) (transactions.TxHash, error) {
 	err := p.checkValidPrimitiveStream(ctx)
 	if err != nil {
 		return transactions.TxHash{}, errors.WithStack(err)
@@ -103,5 +104,5 @@ func (p *PrimitiveStream) InsertRecordsUnix(ctx context.Context, inputs []types.
 		})
 	}
 
-	return p.checkedExecute(ctx, "insert_record", args)
+	return p.checkedExecute(ctx, "insert_record", args, opts...)
 }

--- a/core/types/primitive_stream.go
+++ b/core/types/primitive_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/golang-sql/civil"
+	"github.com/kwilteam/kwil-db/core/types/client"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 )
 
@@ -21,7 +22,7 @@ type IPrimitiveStream interface {
 	// IStream methods are also available in IPrimitiveStream
 	IStream
 	// InsertRecords inserts records into the stream
-	InsertRecords(ctx context.Context, inputs []InsertRecordInput) (transactions.TxHash, error)
+	InsertRecords(ctx context.Context, inputs []InsertRecordInput, opts ...client.TxOpt) (transactions.TxHash, error)
 	// InsertRecordsUnix inserts records into the stream
-	InsertRecordsUnix(ctx context.Context, inputs []InsertRecordUnixInput) (transactions.TxHash, error)
+	InsertRecordsUnix(ctx context.Context, inputs []InsertRecordUnixInput, opts ...client.TxOpt) (transactions.TxHash, error)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Updated InsertRecords and InsertRecordsUnix methods to accept optional transaction options (opts ...client.TxOpt).
- Modified checkedExecute method to handle the new options parameter, improving flexibility in transaction execution.
- Added necessary imports for client types in both core/contractsapi and core/types packages.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #72 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

not a breaking change