### PR TITLE
feat: receive first value from the timestamp stream

### DIFF
--- a/core/types/primitive_stream.go
+++ b/core/types/primitive_stream.go
@@ -25,4 +25,6 @@ type IPrimitiveStream interface {
 	InsertRecords(ctx context.Context, inputs []InsertRecordInput, opts ...client.TxOpt) (transactions.TxHash, error)
 	// InsertRecordsUnix inserts records into the stream
 	InsertRecordsUnix(ctx context.Context, inputs []InsertRecordUnixInput, opts ...client.TxOpt) (transactions.TxHash, error)
+	// GetFirstRecordUnix gets the first record of the stream with Unix timestamp
+	GetFirstRecordUnix(ctx context.Context, input GetFirstRecordUnixInput) (*StreamRecordUnix, error)
 }

--- a/core/types/stream.go
+++ b/core/types/stream.go
@@ -33,6 +33,11 @@ type GetFirstRecordInput struct {
 	FrozenAt  *time.Time
 }
 
+type GetFirstRecordUnixInput struct {
+	AfterDate *int
+	FrozenAt  *time.Time
+}
+
 type StreamRecord struct {
 	DateValue civil.Date
 	Value     apd.Decimal


### PR DESCRIPTION
# Add GetFirstRecordUnix functionality and improve empty record handling

## Description

- Add `GetFirstRecordUnix` type and method to support Unix timestamp-based first record retrieval
- Change empty record handling to return `nil` instead of error for better UX
- Add comprehensive test coverage for empty stream scenarios

## Related Problem
resolves: #78 

## How Has This Been Tested?

Added new test cases in `primitive_stream_unix_test.go`:
- `EmptyStreamOperations`: verifies correct behavior when stream has no records
  - Tests empty stream without parameters
  - Tests empty stream with afterDate parameter
- Extended existing `DeploymentWriteAndReadOperations` test to verify non-empty stream behavior
- All tests pass successfully