### PR TITLE
feat: get stream id without validation or modification

### DIFF
--- a/core/util/stream_id.go
+++ b/core/util/stream_id.go
@@ -42,6 +42,10 @@ func NewStreamId(s string) (*StreamId, error) {
 	return &id, nil
 }
 
+func NewRawStreamId(s string) *StreamId {
+	return &StreamId{id: s}
+}
+
 func (s *StreamId) Validate() error {
 	// verify if the string is a valid stream id
 	if len(s.id) != 32 || s.id[:2] != "st" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request introduces a new function to the `core/util/stream_id.go` file to allow the creation of a `StreamId` without validation. 

Key change:

* Added `NewRawStreamId` function to create a `StreamId` directly from a string without performing validation.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/adapters/issues/102

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
