### PR TITLE
feat: set taxonomy with end date

### DIFF
--- a/core/contracts/composed_stream_template.kf
+++ b/core/contracts/composed_stream_template.kf
@@ -12,7 +12,8 @@ table taxonomies {
     created_at          int     notnull,    //  block height
     disabled_at         int,                //  block height
     version             int     notnull,
-    start_date          text // indicates the start date of when the taxonomy is valid. i.e. when the weight starts to be used
+    start_date          text, // indicates the start date of when the taxonomy is valid. i.e. when the weight starts to be used
+    end_date            text // indicates the end date of when the taxonomy is valid. i.e. when the weight stops to be used
 }
 
 table metadata {
@@ -802,7 +803,7 @@ procedure get_current_version($show_disabled bool) private view returns (result 
 // - gets an array of values for each properties, zipping them as needed
 // - increases the version
 // - adds taxonomy records in batch
-procedure set_taxonomy($data_providers text[], $stream_ids text[], $weights decimal(36,18)[], $start_date text) public {
+procedure set_taxonomy($data_providers text[], $stream_ids text[], $weights decimal(36,18)[], $start_date text, $end_date text) public {
     stream_owner_only();
 
     $next_version int := get_current_version(true) + 1;
@@ -822,8 +823,8 @@ procedure set_taxonomy($data_providers text[], $stream_ids text[], $weights deci
     for $i in 1..$length {
         $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
 
-        INSERT INTO taxonomies (taxonomy_id, child_stream_id, child_data_provider, weight, created_at, version, start_date)
-            VALUES ($current_uuid, $stream_ids[$i], $data_providers[$i], $weights[$i], $block_height, $next_version, $start_date);
+        INSERT INTO taxonomies (taxonomy_id, child_stream_id, child_data_provider, weight, created_at, version, start_date, end_date)
+            VALUES ($current_uuid, $stream_ids[$i], $data_providers[$i], $weights[$i], $block_height, $next_version, $start_date, $end_date);
     }
 }
 
@@ -833,7 +834,8 @@ procedure describe_taxonomies($latest_version bool) public view returns table(
         weight decimal(36,18),
         created_at int,
         version int,
-        start_date text
+        start_date text,
+        end_date text
         ) {
 
         if $latest_version == true {
@@ -844,7 +846,8 @@ procedure describe_taxonomies($latest_version bool) public view returns table(
                 weight,
                 created_at,
                 version,
-                start_date
+                start_date,
+                end_date
             FROM taxonomies
             WHERE version = get_current_version(false) AND disabled_at IS NULL
             ORDER BY created_at DESC;
@@ -855,7 +858,8 @@ procedure describe_taxonomies($latest_version bool) public view returns table(
                 weight,
                 created_at,
                 version,
-                start_date
+                start_date,
+                end_date
             FROM taxonomies
             WHERE disabled_at IS NULL
             ORDER BY version DESC;
@@ -1088,6 +1092,7 @@ procedure get_dynamic_weight($stream_id text, $date_value text) private view ret
     FROM taxonomies
     WHERE child_stream_id = $stream_id
     AND (start_date IS NULL OR start_date = '' OR start_date <= $date_value)
+    AND (end_date IS NULL OR end_date = '' OR end_date >= $date_value)
     ORDER BY start_date DESC
     LIMIT 1 {
         return $row.weight;

--- a/core/contracts/composed_stream_template_unix.kf
+++ b/core/contracts/composed_stream_template_unix.kf
@@ -12,7 +12,8 @@ table taxonomies {
     created_at          int     notnull,    //  block height
     disabled_at         int,                //  block height
     version             int     notnull,
-    start_date          int // indicates the start date of when the taxonomy is valid. i.e. when the weight starts to be used
+    start_date          int, // indicates the start date of when the taxonomy is valid. i.e. when the weight starts to be used
+    end_date            int // indicates the end date of when the taxonomy is valid. i.e. when the weight stops to be used
 }
 
 table metadata {
@@ -802,7 +803,7 @@ procedure get_current_version($show_disabled bool) private view returns (result 
 // - gets an array of values for each properties, zipping them as needed
 // - increases the version
 // - adds taxonomy records in batch
-procedure set_taxonomy($data_providers text[], $stream_ids text[], $weights decimal(36,18)[], $start_date int) public {
+procedure set_taxonomy($data_providers text[], $stream_ids text[], $weights decimal(36,18)[], $start_date int, $end_date int) public {
     stream_owner_only();
 
     $next_version int := get_current_version(true) + 1;
@@ -822,8 +823,8 @@ procedure set_taxonomy($data_providers text[], $stream_ids text[], $weights deci
     for $i in 1..$length {
         $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
 
-        INSERT INTO taxonomies (taxonomy_id, child_stream_id, child_data_provider, weight, created_at, version, start_date)
-            VALUES ($current_uuid, $stream_ids[$i], $data_providers[$i], $weights[$i], $block_height, $next_version, $start_date);
+        INSERT INTO taxonomies (taxonomy_id, child_stream_id, child_data_provider, weight, created_at, version, start_date, end_date)
+            VALUES ($current_uuid, $stream_ids[$i], $data_providers[$i], $weights[$i], $block_height, $next_version, $start_date, $end_date);
     }
 }
 
@@ -833,7 +834,8 @@ procedure describe_taxonomies($latest_version bool) public view returns table(
         weight decimal(36,18),
         created_at int,
         version int,
-        start_date int
+        start_date int,
+        end_date int
         ) {
 
         if $latest_version == true {
@@ -844,7 +846,8 @@ procedure describe_taxonomies($latest_version bool) public view returns table(
                 weight,
                 created_at,
                 version,
-                start_date
+                start_date,
+                end_date
             FROM taxonomies
             WHERE version = get_current_version(false) AND disabled_at IS NULL
             ORDER BY created_at DESC;
@@ -855,7 +858,8 @@ procedure describe_taxonomies($latest_version bool) public view returns table(
                 weight,
                 created_at,
                 version,
-                start_date
+                start_date,
+                end_date
             FROM taxonomies
             WHERE disabled_at IS NULL
             ORDER BY version DESC;
@@ -1088,6 +1092,7 @@ procedure get_dynamic_weight($stream_id text, $date_value int) private view retu
     FROM taxonomies
     WHERE child_stream_id = $stream_id
     AND (start_date IS NULL OR start_date = 0 OR start_date <= $date_value)
+    AND (end_date IS NULL OR end_date = 0 OR end_date >= $date_value)
     ORDER BY start_date DESC
     LIMIT 1 {
         return $row.weight;

--- a/core/types/composed_stream.go
+++ b/core/types/composed_stream.go
@@ -12,11 +12,13 @@ import (
 type Taxonomy struct {
 	TaxonomyItems []TaxonomyItem
 	StartDate     *civil.Date
+	EndDate       *civil.Date
 }
 
 type TaxonomyUnix struct {
 	TaxonomyItems []TaxonomyItem
 	StartDate     *int
+	EndDate       *int
 }
 
 type TaxonomyItem struct {

--- a/tests/integration/composed_stream_test.go
+++ b/tests/integration/composed_stream_test.go
@@ -111,6 +111,7 @@ func TestComposedStream(t *testing.T) {
 					Weight: 2,
 				}},
 			StartDate: unsafeParseDate("2020-01-30"),
+			EndDate:   unsafeParseDate("2020-12-31"),
 		})
 		assertNoErrorOrFail(t, err, "Failed to set taxonomies")
 		waitTxToBeMinedWithSuccess(t, ctx, tnClient, txHashTaxonomies)
@@ -122,6 +123,7 @@ func TestComposedStream(t *testing.T) {
 		assertNoErrorOrFail(t, err, "Failed to describe taxonomies")
 		assert.Equal(t, 2, len(taxonomies.TaxonomyItems))
 		assert.Equal(t, time.Date(2020, 1, 30, 0, 0, 0, 0, time.UTC).Format(time.DateOnly), taxonomies.StartDate.String())
+		assert.Equal(t, time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC).Format(time.DateOnly), taxonomies.EndDate.String())
 
 		// Step 5: Query the composed stream for records
 		// Query records within a specific date range

--- a/tests/integration/composed_stream_unix_test.go
+++ b/tests/integration/composed_stream_unix_test.go
@@ -94,6 +94,7 @@ func TestComposedStreamUnix(t *testing.T) {
 		// Step 4: Set taxonomies for the composed stream
 		// Taxonomies define the structure of the composed stream
 		mockStartDate := 3
+		mockEndDate := 99
 		txHashTaxonomies, err := deployedComposedStream.SetTaxonomyUnix(ctx, types.TaxonomyUnix{
 			TaxonomyItems: []types.TaxonomyItem{
 				{
@@ -111,6 +112,7 @@ func TestComposedStreamUnix(t *testing.T) {
 					Weight: 2,
 				}},
 			StartDate: &mockStartDate,
+			EndDate:   &mockEndDate,
 		})
 		assertNoErrorOrFail(t, err, "Failed to set taxonomies")
 		waitTxToBeMinedWithSuccess(t, ctx, tnClient, txHashTaxonomies)
@@ -122,6 +124,7 @@ func TestComposedStreamUnix(t *testing.T) {
 		assertNoErrorOrFail(t, err, "Failed to describe taxonomies")
 		assert.Equal(t, 2, len(taxonomies.TaxonomyItems))
 		assert.Equal(t, 3, *taxonomies.StartDate)
+		assert.Equal(t, 99, *taxonomies.EndDate)
 
 		// Step 5: Query the composed stream for records
 		// Query records within a specific date range


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request introduces changes to the `core/contracts/composed_stream_template.kf`, `core/contracts/composed_stream_template_unix.kf`, `core/contractsapi/composed_stream.go`, `core/types/composed_stream.go`, and related test files to add support for an `end_date` field in taxonomies. The changes ensure that taxonomies have both start and end dates, allowing for more precise control over their validity periods.

### Schema and Procedure Updates:

* Added `end_date` field to the `taxonomies` table and updated relevant procedures to handle this new field in `core/contracts/composed_stream_template.kf` and `core/contracts/composed_stream_template_unix.kf`. [[1]](diffhunk://#diff-54db118729c74004bc005f49f1b3b760833945b7954bdcf56626de3fa8d10a2dL15-R16) [[2]](diffhunk://#diff-54db118729c74004bc005f49f1b3b760833945b7954bdcf56626de3fa8d10a2dL805-R806) [[3]](diffhunk://#diff-54db118729c74004bc005f49f1b3b760833945b7954bdcf56626de3fa8d10a2dL825-R827) [[4]](diffhunk://#diff-54db118729c74004bc005f49f1b3b760833945b7954bdcf56626de3fa8d10a2dL836-R838) [[5]](diffhunk://#diff-54db118729c74004bc005f49f1b3b760833945b7954bdcf56626de3fa8d10a2dL847-R850) [[6]](diffhunk://#diff-54db118729c74004bc005f49f1b3b760833945b7954bdcf56626de3fa8d10a2dL858-R862) [[7]](diffhunk://#diff-54db118729c74004bc005f49f1b3b760833945b7954bdcf56626de3fa8d10a2dR1095) [[8]](diffhunk://#diff-c2a5f16d4e2538e897f4d7410617af2756dbe8d6afb6fc248540c036227f4540L15-R16) [[9]](diffhunk://#diff-c2a5f16d4e2538e897f4d7410617af2756dbe8d6afb6fc248540c036227f4540L805-R806) [[10]](diffhunk://#diff-c2a5f16d4e2538e897f4d7410617af2756dbe8d6afb6fc248540c036227f4540L825-R827) [[11]](diffhunk://#diff-c2a5f16d4e2538e897f4d7410617af2756dbe8d6afb6fc248540c036227f4540L836-R838) [[12]](diffhunk://#diff-c2a5f16d4e2538e897f4d7410617af2756dbe8d6afb6fc248540c036227f4540L847-R850) [[13]](diffhunk://#diff-c2a5f16d4e2538e897f4d7410617af2756dbe8d6afb6fc248540c036227f4540L858-R862) [[14]](diffhunk://#diff-c2a5f16d4e2538e897f4d7410617af2756dbe8d6afb6fc248540c036227f4540R1095)

### API and Type Updates:

* Updated `DescribeTaxonomiesResult` and `DescribeTaxonomiesUnixResult` structs to include `end_date` in `core/contractsapi/composed_stream.go`. [[1]](diffhunk://#diff-ed1ac9bc894ab61c93e23dbad352c2b40d821a13cb53f2adb4f0681cacddd9d0R81) [[2]](diffhunk://#diff-ed1ac9bc894ab61c93e23dbad352c2b40d821a13cb53f2adb4f0681cacddd9d0R93)
* Modified `DescribeTaxonomies` and `DescribeTaxonomiesUnix` methods to parse and return `end_date` in `core/contractsapi/composed_stream.go`. [[1]](diffhunk://#diff-ed1ac9bc894ab61c93e23dbad352c2b40d821a13cb53f2adb4f0681cacddd9d0R136-R148) [[2]](diffhunk://#diff-ed1ac9bc894ab61c93e23dbad352c2b40d821a13cb53f2adb4f0681cacddd9d0R188-R196)
* Updated `SetTaxonomy` and `SetTaxonomyUnix` methods to accept and handle `end_date` in `core/contractsapi/composed_stream.go`. [[1]](diffhunk://#diff-ed1ac9bc894ab61c93e23dbad352c2b40d821a13cb53f2adb4f0681cacddd9d0R206) [[2]](diffhunk://#diff-ed1ac9bc894ab61c93e23dbad352c2b40d821a13cb53f2adb4f0681cacddd9d0R235)
* Added `EndDate` field to `Taxonomy` and `TaxonomyUnix` structs in `core/types/composed_stream.go`.

### Test Updates:

* Updated integration tests to include `end_date` in `tests/integration/composed_stream_test.go` and `tests/integration/composed_stream_unix_test.go`. [[1]](diffhunk://#diff-db167853d8a1441078fd31ba3cea97247af58713eea6248388e821c8e6ec7897R114) [[2]](diffhunk://#diff-db167853d8a1441078fd31ba3cea97247af58713eea6248388e821c8e6ec7897R126) [[3]](diffhunk://#diff-7bf7498066a272705f8e7c3bfe303bfd6405a85b7625bb4148f9f4feb1f82d88R97) [[4]](diffhunk://#diff-7bf7498066a272705f8e7c3bfe303bfd6405a85b7625bb4148f9f4feb1f82d88R115) [[5]](diffhunk://#diff-7bf7498066a272705f8e7c3bfe303bfd6405a85b7625bb4148f9f4feb1f82d88R127)

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolved: https://github.com/trufnetwork/sdk-go/issues/81

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit test passed