### PR TITLE
feat: get first record from a stream

### DIFF
--- a/core/contractsapi/stream_procedures.go
+++ b/core/contractsapi/stream_procedures.go
@@ -254,19 +254,24 @@ func (s *Action) GetFirstRecord(ctx context.Context, input types.GetFirstRecordI
 		return nil, errors.WithStack(err)
 	}
 
+	eventTime, err := func() (int, error) {
+		if rawOutput.EventTime == "" {
+			return 0, nil
+		}
+
+		eventTime, err := strconv.Atoi(rawOutput.EventTime)
+		if err != nil {
+			return 0, errors.WithStack(err)
+		}
+
+			return eventTime, nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.StreamRecord{
-		EventTime: func() int {
-			if rawOutput.EventTime == "" {
-				return 0
-			}
-
-			eventTime, err := strconv.Atoi(rawOutput.EventTime)
-			if err != nil {
-				return 0
-			}
-
-			return eventTime
-		}(),
+		EventTime: eventTime,
 		Value: *value,
 	}, nil
 }

--- a/core/types/stream.go
+++ b/core/types/stream.go
@@ -3,11 +3,9 @@ package types
 import (
 	"context"
 	"github.com/cockroachdb/apd/v3"
-	"github.com/golang-sql/civil"
 	kwilType "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/types"
 	"github.com/trufnetwork/sdk-go/core/util"
-	"time"
 )
 
 type GetRecordInput struct {
@@ -22,13 +20,10 @@ type GetRecordInput struct {
 type GetIndexInput = GetRecordInput
 
 type GetFirstRecordInput struct {
-	AfterDate *civil.Date
-	FrozenAt  *time.Time
-}
-
-type GetFirstRecordUnixInput struct {
-	AfterDate *int
-	FrozenAt  *time.Time
+	DataProvider string
+	StreamId     string
+	After        *int
+	FrozenAt     *int
 }
 
 type StreamRecord struct {
@@ -71,7 +66,7 @@ type IAction interface {
 	// GetType gets the type of the stream -- Primitive or Composed
 	GetType(ctx context.Context, locator StreamLocator) (StreamType, error)
 	// GetFirstRecord gets the first record of the stream
-	//GetFirstRecord(ctx context.Context, input GetFirstRecordInput) (*StreamRecord, error)
+	GetFirstRecord(ctx context.Context, input GetFirstRecordInput) (*StreamRecord, error)
 
 	// SetReadVisibility sets the read visibility of the stream -- Private or Public
 	SetReadVisibility(ctx context.Context, input VisibilityInput) (types.Hash, error)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request includes significant updates to the stream procedures and related tests in the `core` module. The changes primarily focus on refactoring the `GetFirstRecord` functionality, updating its input structure, and enhancing the integration tests to reflect these updates.

Refactoring and functionality updates:

* [`core/contractsapi/stream_procedures.go`](diffhunk://#diff-148344d9988d98b755aac9ec6d8a94198b8c92d93ca3afc6d82ffcd504cbc978L230-R272): Refactored the `GetFirstRecord` method to use a new input structure and updated its logic for handling optional arguments and parsing results.

Input structure updates:

* [`core/types/stream.go`](diffhunk://#diff-43cbe295ede7ffece0864e9e613a8808c8cc3424632dd1b23f665162599aa153L25-R26): Removed the `GetFirstRecordUnixInput` type and updated the `GetFirstRecordInput` type to include new fields `DataProvider`, `StreamId`, `After`, and `FrozenAt`.
* [`core/types/stream.go`](diffhunk://#diff-43cbe295ede7ffece0864e9e613a8808c8cc3424632dd1b23f665162599aa153L74-R69): Updated the `IAction` interface to include the new `GetFirstRecord` method signature.

Integration test updates:

* [`tests/integration/primitive_actions_test.go`](diffhunk://#diff-177c0ab2e4d1c75041fb42d190697480d389b34fde74a1554493ae133fec4d57L64-R83): Updated the `TestPrimitiveActions` function to include tests for the new `GetFirstRecord` method, ensuring it handles empty streams and valid records correctly. [[1]](diffhunk://#diff-177c0ab2e4d1c75041fb42d190697480d389b34fde74a1554493ae133fec4d57L64-R83) [[2]](diffhunk://#diff-177c0ab2e4d1c75041fb42d190697480d389b34fde74a1554493ae133fec4d57L111-R141)

Dependency updates:

* [`tests/integration/primitive_actions_test.go`](diffhunk://#diff-177c0ab2e4d1c75041fb42d190697480d389b34fde74a1554493ae133fec4d57R6): Added the `contractsapi` package to the imports.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/sdk-go/issues/111

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
