### PR TITLE
chore: replace standard client with gatewayClient

### DIFF
--- a/core/contractsapi/batch_deploy_streams.go
+++ b/core/contractsapi/batch_deploy_streams.go
@@ -3,8 +3,8 @@ package contractsapi
 import (
 	"context"
 
-	"github.com/kwilteam/kwil-db/core/client"
 	kwilClientType "github.com/kwilteam/kwil-db/core/client/types"
+	"github.com/kwilteam/kwil-db/core/gatewayclient"
 	kwilType "github.com/kwilteam/kwil-db/core/types"
 	"github.com/pkg/errors"
 	"github.com/trufnetwork/sdk-go/core/types"
@@ -12,8 +12,8 @@ import (
 
 // BatchDeployStreamsInput defines the input for the BatchDeployStreams function.
 type BatchDeployStreamsInput struct {
-	KwilClient  *client.Client           `validate:"required"`
-	Definitions []types.StreamDefinition `validate:"required"`
+	KwilClient  *gatewayclient.GatewayClient `validate:"required"`
+	Definitions []types.StreamDefinition     `validate:"required"`
 	// SchemaName is the name of the schema where create_streams procedure exists.
 	// Typically, it might be empty if it's a root/global procedure.
 	SchemaName string

--- a/core/contractsapi/deploy_stream.go
+++ b/core/contractsapi/deploy_stream.go
@@ -2,17 +2,17 @@ package contractsapi
 
 import (
 	"context"
-	"github.com/kwilteam/kwil-db/core/client"
+	"github.com/kwilteam/kwil-db/core/gatewayclient"
 	kwilTypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/trufnetwork/sdk-go/core/types"
 	"github.com/trufnetwork/sdk-go/core/util"
 )
 
 type DeployStreamInput struct {
-	StreamId   util.StreamId    `validate:"required"`
-	StreamType types.StreamType `validate:"required"`
-	KwilClient *client.Client   `validate:"required"`
-	Deployer   []byte           `validate:"required"`
+	StreamId   util.StreamId                `validate:"required"`
+	StreamType types.StreamType             `validate:"required"`
+	KwilClient *gatewayclient.GatewayClient `validate:"required"`
+	Deployer   []byte                       `validate:"required"`
 }
 
 // DeployStream deploys a stream to TN

--- a/core/contractsapi/destroy_stream.go
+++ b/core/contractsapi/destroy_stream.go
@@ -2,15 +2,15 @@ package contractsapi
 
 import (
 	"context"
-	"github.com/kwilteam/kwil-db/core/client"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
+	"github.com/kwilteam/kwil-db/core/gatewayclient"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/trufnetwork/sdk-go/core/util"
 )
 
 type DestroyStreamInput struct {
-	StreamId   util.StreamId  `validate:"required"`
-	KwilClient *client.Client `validate:"required"`
+	StreamId   util.StreamId                `validate:"required"`
+	KwilClient *gatewayclient.GatewayClient `validate:"required"`
 }
 
 // DestroyStream destroys a stream from TN

--- a/core/contractsapi/stream.go
+++ b/core/contractsapi/stream.go
@@ -3,8 +3,8 @@ package contractsapi
 import (
 	"context"
 	"encoding/hex"
+	"github.com/kwilteam/kwil-db/core/gatewayclient"
 
-	"github.com/kwilteam/kwil-db/core/client"
 	kwilTypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/pkg/errors"
 	"github.com/trufnetwork/sdk-go/core/types"
@@ -13,13 +13,13 @@ import (
 // ## Initializations
 
 type Action struct {
-	_client *client.Client
+	_client *gatewayclient.GatewayClient
 }
 
 var _ types.IAction = (*Action)(nil)
 
 type NewActionOptions struct {
-	Client *client.Client
+	Client *gatewayclient.GatewayClient
 }
 
 var (

--- a/core/tnclient/client.go
+++ b/core/tnclient/client.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/kwilteam/kwil-db/core/client"
 	kwilClientType "github.com/kwilteam/kwil-db/core/client/types"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
+	"github.com/kwilteam/kwil-db/core/gatewayclient"
 	"github.com/kwilteam/kwil-db/core/log"
 	kwilType "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/types"
@@ -22,8 +22,8 @@ import (
 type Client struct {
 	Signer      auth.Signer `validate:"required"`
 	logger      *log.Logger
-	kwilClient  *client.Client `validate:"required"`
-	kwilOptions *kwilClientType.Options
+	kwilClient  *gatewayclient.GatewayClient `validate:"required"`
+	kwilOptions *gatewayclient.GatewayOptions
 }
 
 var _ clientType.Client = (*Client)(nil)
@@ -32,12 +32,14 @@ type Option func(*Client)
 
 func NewClient(ctx context.Context, provider string, options ...Option) (*Client, error) {
 	c := &Client{}
-	c.kwilOptions = kwilClientType.DefaultOptions()
+	c.kwilOptions = &gatewayclient.GatewayOptions{
+		Options: *kwilClientType.DefaultOptions(),
+	}
 	for _, option := range options {
 		option(c)
 	}
 
-	kwilClient, err := client.NewClient(ctx, provider, c.kwilOptions)
+	kwilClient, err := gatewayclient.NewClient(ctx, provider, c.kwilOptions)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -78,7 +80,7 @@ func (c *Client) WaitForTx(ctx context.Context, txHash kwilType.Hash, interval t
 	return c.kwilClient.WaitTx(ctx, txHash, interval)
 }
 
-func (c *Client) GetKwilClient() *client.Client {
+func (c *Client) GetKwilClient() *gatewayclient.GatewayClient {
 	return c.kwilClient
 }
 

--- a/core/types/tsn_client.go
+++ b/core/types/tsn_client.go
@@ -2,9 +2,8 @@ package types
 
 import (
 	"context"
+	"github.com/kwilteam/kwil-db/core/gatewayclient"
 	"time"
-
-	"github.com/kwilteam/kwil-db/core/client"
 
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/trufnetwork/sdk-go/core/util"
@@ -14,7 +13,7 @@ type Client interface {
 	// WaitForTx waits for the transaction to be mined by TN
 	WaitForTx(ctx context.Context, txHash types.Hash, interval time.Duration) (*types.TxQueryResponse, error)
 	// GetKwilClient returns the kwil client used by the client
-	GetKwilClient() *client.Client
+	GetKwilClient() *gatewayclient.GatewayClient
 	// DeployStream deploys a new stream
 	DeployStream(ctx context.Context, streamId util.StreamId, streamType StreamType) (types.Hash, error)
 	// DestroyStream destroys a stream

--- a/examples/main.go
+++ b/examples/main.go
@@ -15,15 +15,18 @@ func main() {
 	streamId := util.GenerateStreamId("test")
 	pk, _ := crypto.Secp256k1PrivateKeyFromHex("0000000000000000000000000000000000000000000000000000000000000001")
 	signer := &auth.EthPersonalSigner{Key: *pk}
-	tnClient, _ := tnclient.NewClient(
+	tnClient, err := tnclient.NewClient(
 		ctx,
 		"http://localhost:8484",
 		tnclient.WithSigner(signer))
+	if err != nil {
+		panic(err)
+	}
 	fmt.Println("streamId: ", streamId)
-	txHash, err := tnClient.DeployStream(ctx, streamId, types.StreamTypePrimitive)
+	listStreams, err := tnClient.ListStreams(ctx, types.ListStreamsInput{})
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Println("txHash: ", txHash)
+	fmt.Println("listStreams: ", listStreams)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

log: this need to be configure on AWS
```
panic: authenticate error: domain mismatch: configured 'https://gateway.infra.truf.network' != remote https://infra.truf.network

goroutine 1 [running]:
main.main()
        /home/micbun/trufnetwork/sdk-go/examples/main.go:28 +0x20f
exit status 2
```

related: https://github.com/trufnetwork/node/pull/930

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/sdk-go/issues/114

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
