### PR TITLE
chore: enable get index change cache metadata support

### DIFF
--- a/core/types/cache_metadata.go
+++ b/core/types/cache_metadata.go
@@ -51,6 +51,12 @@ type StreamIndexWithMetadata struct {
 	Metadata CacheMetadata   `json:"cache_metadata"`
 }
 
+// StreamIndexChangeWithMetadata extends StreamIndexChange with cache metadata
+type StreamIndexChangeWithMetadata struct {
+	IndexChanges []StreamIndexChange `json:"index_changes"`
+	Metadata     CacheMetadata       `json:"cache_metadata"`
+}
+
 
 // ParseCacheMetadata extracts cache metadata from action logs
 func ParseCacheMetadata(logs []string) (CacheMetadata, error) {

--- a/core/types/stream.go
+++ b/core/types/stream.go
@@ -31,6 +31,7 @@ type GetIndexChangeInput struct {
 	BaseDate     *int
 	TimeInterval int
 	Prefix       *string
+	UseCache     *bool
 }
 
 type GetFirstRecordInput struct {
@@ -91,6 +92,8 @@ type IAction interface {
 	GetIndexWithMetadata(ctx context.Context, input GetIndexInput) (StreamIndexWithMetadata, error)
 	// GetIndexChange reads the index change of the stream within the given date range
 	GetIndexChange(ctx context.Context, input GetIndexChangeInput) ([]StreamIndexChange, error)
+	// GetIndexChangeWithMetadata reads the index change of the stream with cache metadata
+	GetIndexChangeWithMetadata(ctx context.Context, input GetIndexChangeInput) (StreamIndexChangeWithMetadata, error)
 	// GetType gets the type of the stream -- Primitive or Composed
 	GetType(ctx context.Context, locator StreamLocator) (StreamType, error)
 	// GetFirstRecord gets the first record of the stream


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

After this PR, we should release a new SDK version, then we continue with https://github.com/trufnetwork/sdk-go/issues/142

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/sdk-go/issues/141

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve index change data along with detailed cache metadata.
  * Introduced an option to use cache when requesting index change information.

* **Tests**
  * Added integration tests to verify retrieval of index changes with metadata and cache usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->