### PR TITLE
chore: include height metadata & ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+
+    steps:
+      - name: Checkout sdk-go
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          check-latest: true
+
+      - name: Install Taskfile
+        uses: arduino/setup-task@v2
+
+      - name: Checkout trufnetwork/node
+        uses: actions/checkout@v4
+        with:
+          repository: trufnetwork/node
+          ref: main
+          path: tmp-node
+
+      - name: Get node commit hash
+        id: node-commit
+        working-directory: tmp-node
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build tn-db Docker image & kwil-cli binary
+        run: |
+          cd tmp-node
+          task docker:build:local
+
+      - name: Cache kwil-cli build
+        id: cache-kwil-build
+        uses: actions/cache@v4
+        with:
+          path: tmp-node/.build
+          key: ${{ runner.os }}-kwil-build-${{ steps.node-commit.outputs.sha }}
+
+      - name: Build kwil-cli binary (if cache miss)
+        if: steps.cache-kwil-build.outputs.cache-hit != 'true'
+        run: |
+          cd tmp-node
+          task build
+
+      - name: Move kwil-cli binary to PATH
+        run: |
+          sudo mv tmp-node/.build/kwil-cli /usr/local/bin/kwil-cli
+          kwil-cli version
+
+      - name: Pull Postgres image
+        run: docker pull kwildb/postgres:16.8-1
+
+      - name: Run all Go tests (unit + integration)
+        env:
+          NODE_REPO_DIR: tmp-node
+        run: |
+          go test ./... -v
+
+      - name: Cleanup Docker resources
+        if: always() && !env.ACT
+        run: docker system prune -af

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run all Go tests (unit + integration)
         env:
-          NODE_REPO_DIR: tmp-node
+          NODE_REPO_DIR: ${{ github.workspace }}/tmp-node
         run: |
           go test ./... -v
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
         working-directory: tmp-node
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build tn-db Docker image & kwil-cli binary
+      - name: Build tn-db Docker image
         run: |
           cd tmp-node
           task docker:build:local
@@ -53,9 +53,9 @@ jobs:
           cd tmp-node
           task build
 
-      - name: Move kwil-cli binary to PATH
+      - name: Copy kwil-cli binary to PATH
         run: |
-          sudo mv tmp-node/.build/kwil-cli /usr/local/bin/kwil-cli
+          sudo cp tmp-node/.build/kwil-cli /usr/local/bin/kwil-cli
           kwil-cli version
 
       - name: Pull Postgres image

--- a/core/types/cache_metadata_test.go
+++ b/core/types/cache_metadata_test.go
@@ -1,0 +1,78 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCacheMetadata(t *testing.T) {
+	tests := []struct {
+		name      string
+		logs      []string
+		expected  CacheMetadata
+		expectErr bool
+	}{
+		{
+			name: "Successful parse with cache hit and height",
+			logs: []string{
+				`{"cache_hit": true, "cache_height": 1000}`,
+			},
+			expected: CacheMetadata{
+				CacheHit:    true,
+				CacheHeight: int64Ptr(1000),
+			},
+			expectErr: false,
+		},
+		{
+			name: "Parse cache miss",
+			logs: []string{
+				`{"cache_hit": false}`,
+			},
+			expected: CacheMetadata{
+				CacheHit: false,
+			},
+			expectErr: false,
+		},
+		{
+			name: "Parse cache disabled",
+			logs: []string{
+				`{"cache_disabled": true}`,
+			},
+			expected: CacheMetadata{
+				CacheDisabled: true,
+			},
+			expectErr: false,
+		},
+		{
+			name: "Invalid JSON log",
+			logs: []string{
+				"invalid json",
+			},
+			expected:  CacheMetadata{},
+			expectErr: false, // Should skip invalid logs
+		},
+		{
+			name:      "No logs",
+			logs:      []string{},
+			expected:  CacheMetadata{},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCacheMetadata(tt.logs)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			}
+		})
+	}
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -34,6 +34,54 @@ The SDK is structured around several key interfaces:
 - Flexible querying and indexing
 - Granular access control
 
+### Cache Support
+
+Starting with SDK-go vNext the helpers that fetch data from a stream can transparently leverage the node-side cache layer (enabled when the connected node has the `tn_cache` extension).
+
+* **`useCache` parameter** – optional boolean flag now available on all high-level data-retrieval helpers (`GetRecord`, `GetIndex`, `GetFirstRecord`, `GetIndexChange`, `Batch*` variants). If omitted, the method behaves exactly like earlier versions (cache disabled by default for calls that don’t specify the flag).
+* **`types.CacheAwareResponse`** – these helpers now return a struct that embeds the normal payload **and** cache context:
+
+```go
+type CacheAwareResponse[T any] struct {
+    Results  T                `json:"results"`
+    Metadata *types.CacheMetadata `json:"cache_metadata,omitempty"`
+    Logs     []string         `json:"logs,omitempty"`
+}
+```
+
+* **`types.CacheMetadata`** – enriched structure returned in `Metadata`:
+
+| Field            | Type    | Description                                            |
+|------------------|---------|--------------------------------------------------------|
+| `CacheHit`       | bool    | Whether the query was served by the cache              |
+| `CacheDisabled`  | bool    | True if the node had cache disabled for this query     |
+| `CacheHeight`   | *int64  | **NEW** – block height at which the cached data was produced |
+| `RowsServed`     | int     | Number of rows returned by the query (SDK-calculated)  |
+| `StreamId`       | string  | Stream identifier supplied by the SDK                  |
+| `DataProvider`   | string  | Address of the data-provider                           |
+
+> **Note**: `CacheHeight` is only present if the node included height information in its NOTICE logs (requires a v0.10.0+ node with `tn_cache` ≥ 0.6.0).
+
+Example checking cache metadata:
+
+```go
+records, err := primitiveActions.GetRecord(ctx, types.GetRecordInput{
+    DataProvider: streamLocator.DataProvider.Address(),
+    StreamId:     streamLocator.StreamId.String(),
+    From:         intPtr(1),
+    To:           intPtr(100),
+    UseCache:     boolPtr(true),
+})
+
+if err == nil && records.Metadata != nil && records.Metadata.CacheHit {
+    fmt.Printf("cache hit at height %d\n",
+        derefInt64(records.Metadata.CacheHeight),
+    )
+}
+```
+
+The legacy method signatures remain available but are **deprecated**; a one-time warning is logged when they are used.
+
 ## Example Usage
 
 ```go

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -321,8 +321,8 @@ type CacheMetadata struct {
     CacheHit      bool  `json:"cache_hit"`        // Whether the query hit the cache
     CacheDisabled bool  `json:"cache_disabled"`   // Whether caching is disabled
     
-    // Cache timing information
-    CachedAt      *int64 `json:"cached_at"`       // Unix timestamp when data was cached
+    // Cache height information
+    CacheHeight   *int64 `json:"cache_height"`    // Block height when data was cached
     
     // Query context (populated by SDK)
     StreamId      string `json:"stream_id"`       // Stream identifier
@@ -333,13 +333,6 @@ type CacheMetadata struct {
     RowsServed    int    `json:"rows_served"`    // Number of rows returned
 }
 ```
-
-#### Cache Metadata Methods
-
-The `CacheMetadata` type provides helper methods for analyzing cache performance:
-
-- `GetDataAge() *time.Duration`: Returns the age of cached data. Returns `nil` if no cache timestamp is available.
-- `IsExpired(maxAge time.Duration) bool`: Checks if cached data is older than the specified duration.
 
 #### Performance Analysis
 
@@ -360,16 +353,11 @@ if err != nil {
 // Analyze cache performance
 if result.Metadata.CacheHit {
     fmt.Printf("Cache hit! Served %d rows from cache\n", result.Metadata.RowsServed)
-    if dataAge := result.Metadata.GetDataAge(); dataAge != nil {
-        fmt.Printf("Cache age: %v\n", *dataAge)
+    if result.Metadata.CacheHeight != nil {
+        fmt.Printf("Cache height: %d\n", *result.Metadata.CacheHeight)
     }
 } else {
     fmt.Printf("Cache miss - data retrieved from database\n")
-}
-
-// Check if cache data is too old
-if result.Metadata.IsExpired(5 * time.Minute) {
-    fmt.Println("Warning: Cache data is older than 5 minutes")
 }
 ```
 
@@ -446,17 +434,14 @@ if err != nil {
 // Performance analysis
 if result.Metadata.CacheHit {
     fmt.Printf("✓ Cache hit! Query served in optimized time\n")
-    if dataAge := result.Metadata.GetDataAge(); dataAge != nil {
-        fmt.Printf("Cache age: %v\n", *dataAge)
+    if result.Metadata.CacheHeight != nil {
+        fmt.Printf("Cache height: %d\n", *result.Metadata.CacheHeight)
     }
 } else {
     fmt.Printf("○ Cache miss - data retrieved from source\n")
 }
 
-// Validate cache freshness
-if result.Metadata.IsExpired(10 * time.Minute) {
-    fmt.Println("⚠ Warning: Cache data is older than 10 minutes")
-}
+
 ```
 
 **Behaviour**
@@ -772,12 +757,9 @@ if aggregated.CacheHitRate < 0.5 {
     log.Printf("Low cache hit rate: %.2f%%", aggregated.CacheHitRate*100)
 }
 
-// 3. Check cache date to determine data freshness
-// The cache doesn't expire but shows when data was cached
-if result.Metadata.CachedAt != nil &&
-   time.Since(time.Unix(*result.Metadata.CachedAt, 0)) > 5*time.Minute {
-    // Data is older than 5 minutes - decide if this is acceptable
-    // Contact node operator if more frequent updates are needed
+// 3. Analyze cache height for data consistency
+if result.Metadata.CacheHeight != nil {
+    fmt.Printf("Data cached at block height: %d\n", *result.Metadata.CacheHeight)
 }
 ```
 

--- a/tests/unit/cache_test.go
+++ b/tests/unit/cache_test.go
@@ -13,7 +13,7 @@ import (
 func TestParseLogMetadata(t *testing.T) {
 	t.Run("Parse cache hit log", func(t *testing.T) {
 		logs := []string{
-			`{"cache_hit": true}`,
+			`{"cache_hit": true, "cache_height": 12345}`,
 		}
 
 		metadata, err := types.ParseCacheMetadata(logs)
@@ -21,6 +21,8 @@ func TestParseLogMetadata(t *testing.T) {
 
 		assert.True(t, metadata.CacheHit, "Should parse cache hit as true")
 		assert.False(t, metadata.CacheDisabled, "Should not be disabled")
+		require.NotNil(t, metadata.CacheHeight, "CacheHeight should not be nil for cache hit")
+		assert.Equal(t, int64(12345), *metadata.CacheHeight, "Should parse cache height")
 	})
 
 	t.Run("Parse cache miss log", func(t *testing.T) {
@@ -49,7 +51,7 @@ func TestParseLogMetadata(t *testing.T) {
 	t.Run("Parse multiple logs", func(t *testing.T) {
 		logs := []string{
 			`some non-json log line`,
-			`{"cache_hit": true}`,
+			`{"cache_hit": true, "cache_height": 9876}`,
 			`another non-json line`,
 		}
 
@@ -57,6 +59,8 @@ func TestParseLogMetadata(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, metadata.CacheHit, "Should parse cache hit from valid JSON")
+		require.NotNil(t, metadata.CacheHeight, "CacheHeight should not be nil for cache hit")
+		assert.Equal(t, int64(9876), *metadata.CacheHeight, "Should parse cache height")
 	})
 
 	t.Run("Parse empty logs", func(t *testing.T) {

--- a/tests/unit/cache_test.go
+++ b/tests/unit/cache_test.go
@@ -3,7 +3,6 @@ package unit
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,16 +13,14 @@ import (
 func TestParseLogMetadata(t *testing.T) {
 	t.Run("Parse cache hit log", func(t *testing.T) {
 		logs := []string{
-			`{"cache_hit": true, "cached_at": 1234567890}`,
+			`{"cache_hit": true}`,
 		}
 
 		metadata, err := types.ParseCacheMetadata(logs)
 		require.NoError(t, err)
-		
+
 		assert.True(t, metadata.CacheHit, "Should parse cache hit as true")
 		assert.False(t, metadata.CacheDisabled, "Should not be disabled")
-		require.NotNil(t, metadata.CachedAt, "CachedAt should not be nil")
-		assert.Equal(t, int64(1234567890), *metadata.CachedAt, "Should parse cached_at timestamp")
 	})
 
 	t.Run("Parse cache miss log", func(t *testing.T) {
@@ -33,9 +30,8 @@ func TestParseLogMetadata(t *testing.T) {
 
 		metadata, err := types.ParseCacheMetadata(logs)
 		require.NoError(t, err)
-		
+
 		assert.False(t, metadata.CacheHit, "Should parse cache hit as false")
-		assert.Nil(t, metadata.CachedAt, "CachedAt should be nil for miss")
 	})
 
 	t.Run("Parse cache disabled log", func(t *testing.T) {
@@ -45,7 +41,7 @@ func TestParseLogMetadata(t *testing.T) {
 
 		metadata, err := types.ParseCacheMetadata(logs)
 		require.NoError(t, err)
-		
+
 		assert.False(t, metadata.CacheHit, "Should not be cache hit")
 		assert.True(t, metadata.CacheDisabled, "Should be disabled")
 	})
@@ -53,16 +49,14 @@ func TestParseLogMetadata(t *testing.T) {
 	t.Run("Parse multiple logs", func(t *testing.T) {
 		logs := []string{
 			`some non-json log line`,
-			`{"cache_hit": true, "cached_at": 1234567890}`,
+			`{"cache_hit": true}`,
 			`another non-json line`,
 		}
 
 		metadata, err := types.ParseCacheMetadata(logs)
 		require.NoError(t, err)
-		
+
 		assert.True(t, metadata.CacheHit, "Should parse cache hit from valid JSON")
-		require.NotNil(t, metadata.CachedAt, "Should parse timestamp")
-		assert.Equal(t, int64(1234567890), *metadata.CachedAt)
 	})
 
 	t.Run("Parse empty logs", func(t *testing.T) {
@@ -70,11 +64,10 @@ func TestParseLogMetadata(t *testing.T) {
 
 		metadata, err := types.ParseCacheMetadata(logs)
 		require.NoError(t, err)
-		
+
 		// Should return zero-value metadata
 		assert.False(t, metadata.CacheHit)
 		assert.False(t, metadata.CacheDisabled)
-		assert.Nil(t, metadata.CachedAt)
 	})
 }
 
@@ -84,7 +77,6 @@ func TestCacheMetadataJSON(t *testing.T) {
 		original := types.CacheMetadata{
 			CacheHit:      true,
 			CacheDisabled: false,
-			CachedAt:      &[]int64{1234567890}[0],
 			StreamId:      "test_stream_id",
 			DataProvider:  "0x1234567890abcdef",
 			From:          &[]int64{1}[0],
@@ -100,7 +92,6 @@ func TestCacheMetadataJSON(t *testing.T) {
 		// Verify the JSON contains the expected field names
 		jsonStr := string(jsonBytes)
 		assert.Contains(t, jsonStr, `"cache_hit":true`, "Should contain cache_hit field")
-		assert.Contains(t, jsonStr, `"cached_at":1234567890`, "Should contain cached_at field")
 		assert.Contains(t, jsonStr, `"stream_id":"test_stream_id"`, "Should contain stream_id field")
 		assert.Contains(t, jsonStr, `"rows_served":42`, "Should contain rows_served field")
 
@@ -115,13 +106,10 @@ func TestCacheMetadataJSON(t *testing.T) {
 		assert.Equal(t, original.StreamId, unmarshaled.StreamId)
 		assert.Equal(t, original.DataProvider, unmarshaled.DataProvider)
 		assert.Equal(t, original.RowsServed, unmarshaled.RowsServed)
-		
-		require.NotNil(t, unmarshaled.CachedAt)
-		assert.Equal(t, *original.CachedAt, *unmarshaled.CachedAt)
-		
+
 		require.NotNil(t, unmarshaled.From)
 		assert.Equal(t, *original.From, *unmarshaled.From)
-		
+
 		require.NotNil(t, unmarshaled.To)
 		assert.Equal(t, *original.To, *unmarshaled.To)
 	})
@@ -175,54 +163,5 @@ func TestAggregation(t *testing.T) {
 		assert.Equal(t, 2, result.CacheMisses)
 		assert.Equal(t, 0.0, result.CacheHitRate, "Hit rate should be 0%")
 		assert.Equal(t, 8, result.TotalRowsServed)
-	})
-}
-
-// TestDataAge tests the cache age calculation functionality
-func TestDataAge(t *testing.T) {
-	t.Run("GetDataAge with recent timestamp", func(t *testing.T) {
-		now := time.Now()
-		cachedAt := now.Unix() - 300 // 5 minutes ago
-		
-		metadata := types.CacheMetadata{
-			CachedAt: &cachedAt,
-		}
-
-		dataAge := metadata.GetDataAge()
-		require.NotNil(t, dataAge, "DataAge should not be nil")
-		
-		// Should be approximately 5 minutes (allowing for test execution time)
-		assert.Greater(t, dataAge.Minutes(), 4.9, "Data age should be at least 4.9 minutes")
-		assert.Less(t, dataAge.Minutes(), 5.1, "Data age should be less than 5.1 minutes")
-	})
-
-	t.Run("IsExpired with various ages", func(t *testing.T) {
-		now := time.Now()
-		
-		testCases := []struct {
-			name           string
-			ageMinutes     int
-			maxAge         time.Duration
-			expectedExpired bool
-		}{
-			{"fresh data", 1, 5 * time.Minute, false},
-			{"exact expiry", 5, 5 * time.Minute, true}, // Equal or greater age should be expired
-			{"expired data", 10, 5 * time.Minute, true},
-			{"very old data", 60, 5 * time.Minute, true},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				cachedAt := now.Unix() - int64(tc.ageMinutes*60)
-				metadata := types.CacheMetadata{
-					CachedAt: &cachedAt,
-				}
-
-				isExpired := metadata.IsExpired(tc.maxAge)
-				assert.Equal(t, tc.expectedExpired, isExpired, 
-					"Data aged %d minutes should have expired=%t with maxAge=%v", 
-					tc.ageMinutes, tc.expectedExpired, tc.maxAge)
-			})
-		}
 	})
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Introduced `cache_metadata_test.go` with tests for `ParseCacheMetadata` function covering various scenarios including cache hit, miss, and invalid logs.
- Updated `CacheMetadata` structure to replace `CachedAt` with `CacheHeight` to reflect changes in cache logging.
- Removed references to `CachedAt` in existing tests and documentation to ensure consistency with the new structure.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #148 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation for new cache support in the SDK, including usage of cache-aware response types and metadata.
* **New Features**
  * Introduced a new cache metadata field for block height, enhancing cache context in API responses.
  * Added an optional parameter to enable cache usage in high-level data retrieval helpers.
* **Tests**
  * Added unit tests for parsing cache metadata covering multiple scenarios.
  * Updated existing tests to replace timestamp-based cache metadata with block height.
  * Removed tests related to the deprecated cache timestamp field and related logic.
* **Chores**
  * Introduced a new continuous integration workflow to automate build, test, and cache processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->