### PR TITLE
chore: bulk insert retries through node catch-up events

### DIFF
--- a/core/contractsapi/bulk_inserter.go
+++ b/core/contractsapi/bulk_inserter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,19 +49,21 @@ type BulkInsertTxClient interface {
 // one BulkInserter per signer key, single-threaded.
 //
 // Recovery: on ErrInvalidNonce the cache is cleared and re-fetched from the
-// ledger on the next call. On ErrMempoolFull we backoff but keep the cache
-// (the nonce is still valid, the network is just busy).
+// ledger on the next call. On ErrMempoolFull and "node is catching up" we
+// backoff but keep the cache (the nonce is still valid; the network or the
+// receiving backend is just busy).
 type BulkInserter struct {
 	broadcaster BulkInsertBroadcaster
 	txClient    BulkInsertTxClient
 	accountID   *kwiltypes.AccountID
 	logger      log.Logger
 
-	batchSize    int
-	maxInflight  int
-	maxAttempts  int
-	retryBackoff time.Duration
-	waitInterval time.Duration
+	batchSize      int
+	maxInflight    int
+	maxAttempts    int
+	retryBackoff   time.Duration
+	catchupBackoff time.Duration
+	waitInterval   time.Duration
 
 	mu               sync.Mutex
 	pendingNonce     int64
@@ -108,6 +111,18 @@ func WithRetryBackoff(d time.Duration) BulkInserterOption {
 	return func(b *BulkInserter) {
 		if d > 0 {
 			b.retryBackoff = d
+		}
+	}
+}
+
+// WithCatchupBackoff sets the base backoff used when the broadcast backend
+// rejects with "node is catching up". Catch-up events typically resolve on
+// the order of tens of seconds, so this defaults higher than WithRetryBackoff.
+// Actual delay is catchupBackoff * (attempt + 1). Default: 5s.
+func WithCatchupBackoff(d time.Duration) BulkInserterOption {
+	return func(b *BulkInserter) {
+		if d > 0 {
+			b.catchupBackoff = d
 		}
 	}
 }
@@ -161,15 +176,16 @@ func NewBulkInserter(
 	}
 
 	b := &BulkInserter{
-		broadcaster:  broadcaster,
-		txClient:     txClient,
-		accountID:    accountID,
-		logger:       log.DiscardLogger,
-		batchSize:    10,
-		maxInflight:  200,
-		maxAttempts:  5,
-		retryBackoff: 2 * time.Second,
-		waitInterval: 1 * time.Second,
+		broadcaster:    broadcaster,
+		txClient:       txClient,
+		accountID:      accountID,
+		logger:         log.DiscardLogger,
+		batchSize:      10,
+		maxInflight:    200,
+		maxAttempts:    5,
+		retryBackoff:   2 * time.Second,
+		catchupBackoff: 5 * time.Second,
+		waitInterval:   1 * time.Second,
 	}
 	for _, opt := range opts {
 		opt(b)
@@ -308,6 +324,14 @@ func (b *BulkInserter) broadcastWithRetry(
 			if waitErr := b.backoff(ctx, attempt); waitErr != nil {
 				return kwiltypes.Hash{}, waitErr
 			}
+		case isCatchingUpErr(err):
+			b.logger.Warn("bulk_inserter: backend catching up, backing off",
+				"attempt", attempt+1, "nonce", nonce, "err", err)
+			// Keep nonceLoaded=true — the backend never admitted the tx, our
+			// cached nonce is still correct.
+			if waitErr := b.backoffCatchup(ctx, attempt); waitErr != nil {
+				return kwiltypes.Hash{}, waitErr
+			}
 		default:
 			return kwiltypes.Hash{}, err
 		}
@@ -323,6 +347,34 @@ func (b *BulkInserter) backoff(ctx context.Context, attempt int) error {
 	case <-time.After(delay):
 		return nil
 	}
+}
+
+// backoffCatchup uses a longer base than backoff() because catch-up events
+// typically resolve in tens of seconds, not single seconds. Linear ramp.
+func (b *BulkInserter) backoffCatchup(ctx context.Context, attempt int) error {
+	delay := b.catchupBackoff * time.Duration(attempt+1)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(delay):
+		return nil
+	}
+}
+
+// isCatchingUpErr reports whether err is a kwild "node is catching up"
+// rejection. kwild emits this from node/node.go as a raw errors.New and the
+// RPC layer surfaces it as a BroadcastError with TxCode 65535
+// (CodeUnknownError). There is no exported sentinel in kwil-db today, so we
+// match by substring on the literal message kwild produces.
+//
+// TODO: replace with errors.Is(err, kwiltypes.ErrCatchingUp) once kwil-db
+// exports a typed sentinel + dedicated TxCode (P1 follow-up tracked in
+// 0MainnetPredictionMarket/6IncidentTriage-NodeCatchingUp-2026-04-21.md).
+func isCatchingUpErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "node is catching up")
 }
 
 func (b *BulkInserter) drain(ctx context.Context, hashes []kwiltypes.Hash) error {

--- a/core/contractsapi/bulk_inserter.go
+++ b/core/contractsapi/bulk_inserter.go
@@ -278,12 +278,24 @@ func (b *BulkInserter) InsertAll(
 func (b *BulkInserter) broadcastWithRetry(
 	ctx context.Context,
 	chunk []sdktypes.InsertRecordInput,
-) (kwiltypes.Hash, error) {
+) (hash kwiltypes.Hash, retErr error) {
 	var (
 		lastErr     error
 		nonce       int64
 		nonceLoaded bool
 	)
+	// On any error exit (attempt exhaustion, context cancellation during
+	// backoff, or an unhandled error), drop the cached nonce. The reserved
+	// nonce was never admitted to the network, so a subsequent InsertAll
+	// would otherwise broadcast the next nonce first and only recover via
+	// ErrInvalidNonce — wasting one round-trip every time. Forcing a fresh
+	// GetAccount on the next call resyncs us with what the ledger actually
+	// admitted. Idempotent with the ErrInvalidNonce path's reset.
+	defer func() {
+		if retErr != nil && nonceLoaded {
+			b.resetNonce()
+		}
+	}()
 	for attempt := 0; attempt < b.maxAttempts; attempt++ {
 		// Pull a fresh nonce only on the first attempt OR after an
 		// ErrInvalidNonce reset. On ErrMempoolFull we keep the same nonce

--- a/core/contractsapi/bulk_inserter_test.go
+++ b/core/contractsapi/bulk_inserter_test.go
@@ -276,7 +276,7 @@ func TestBulkInserter_CatchingUp_ContextCancellation(t *testing.T) {
 		failNext: 100,
 		failErr:  errors.New("broadcast error: node is catching up, cannot process transactions right now"),
 	}
-	tc := &mockTxClient{ledgerNonce: 0}
+	tc := &mockTxClient{ledgerNonce: 50}
 	bi, err := contractsapi.NewBulkInserter(bc, tc, newTestSigner(t),
 		contractsapi.WithMaxAttempts(10),
 		contractsapi.WithCatchupBackoff(100*time.Millisecond),
@@ -289,6 +289,24 @@ func TestBulkInserter_CatchingUp_ContextCancellation(t *testing.T) {
 	_, err = bi.InsertAll(ctx, makeInputs(10))
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, context.DeadlineExceeded), "context cancellation should propagate during catchup backoff")
+
+	// The cancelled attempt reserved nonce 51 but never admitted it. The
+	// inserter must drop the cached nonce on the error exit so a follow-up
+	// InsertAll resyncs with the ledger and starts at nonce 51 again — not
+	// at 52, which would force an ErrInvalidNonce round-trip on the network.
+	bc.failNext = 0 // succeed on the next call
+	hashes, err := bi.InsertAll(context.Background(), makeInputs(10))
+	require.NoError(t, err, "follow-up InsertAll should succeed once broadcaster recovers")
+	require.Len(t, hashes, 1)
+
+	calls := bc.snapshot()
+	require.GreaterOrEqual(t, len(calls), 1, "follow-up call should have at least one broadcast")
+	successCall := calls[len(calls)-1]
+	assert.Equal(t, int64(51), successCall.nonce,
+		"follow-up call's first successful broadcast must reuse ledgerNonce+1, proving the cancelled attempt did not permanently advance pendingNonce")
+	// And we should have refetched from the ledger after the cancelled call.
+	assert.Equal(t, 2, tc.getAccountCalls,
+		"follow-up call should refetch from ledger after the prior error exit")
 }
 
 func TestBulkInserter_PersistentFailure_ReturnsBulkInsertError(t *testing.T) {

--- a/core/contractsapi/bulk_inserter_test.go
+++ b/core/contractsapi/bulk_inserter_test.go
@@ -240,6 +240,57 @@ func TestBulkInserter_MempoolFull_BackoffWithoutReset(t *testing.T) {
 	assert.Equal(t, int64(51), calls[1].nonce, "retry should reuse nonce after mempool-full")
 }
 
+func TestBulkInserter_CatchingUp_BackoffWithoutReset(t *testing.T) {
+	// Mirrors the wire-level shape: kwild rejects with a BroadcastError whose
+	// message contains "node is catching up, cannot process transactions
+	// right now" (see kwil-db/node/node.go). Since there's no exported
+	// sentinel in kwil-db today, BulkInserter detects this by substring on
+	// the message.
+	bc := &mockBroadcaster{
+		failNext: 1,
+		failErr:  errors.New("broadcast error: code 65535: node is catching up, cannot process transactions right now"),
+	}
+	tc := &mockTxClient{ledgerNonce: 50}
+	bi, err := contractsapi.NewBulkInserter(bc, tc, newTestSigner(t),
+		contractsapi.WithMaxAttempts(3),
+		contractsapi.WithCatchupBackoff(1*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	hashes, err := bi.InsertAll(context.Background(), makeInputs(10))
+	require.NoError(t, err)
+	assert.Len(t, hashes, 1)
+
+	// Catching-up does NOT trigger nonce reset — only one ledger fetch
+	assert.Equal(t, 1, tc.getAccountCalls, "nonce should NOT be refetched on catching-up")
+	assert.Len(t, bc.snapshot(), 2, "should retry once")
+
+	// Both attempts should reuse the same nonce (51 = ledger+1)
+	calls := bc.snapshot()
+	assert.Equal(t, int64(51), calls[0].nonce)
+	assert.Equal(t, int64(51), calls[1].nonce, "retry should reuse nonce after catching-up")
+}
+
+func TestBulkInserter_CatchingUp_ContextCancellation(t *testing.T) {
+	bc := &mockBroadcaster{
+		failNext: 100,
+		failErr:  errors.New("broadcast error: node is catching up, cannot process transactions right now"),
+	}
+	tc := &mockTxClient{ledgerNonce: 0}
+	bi, err := contractsapi.NewBulkInserter(bc, tc, newTestSigner(t),
+		contractsapi.WithMaxAttempts(10),
+		contractsapi.WithCatchupBackoff(100*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err = bi.InsertAll(ctx, makeInputs(10))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "context cancellation should propagate during catchup backoff")
+}
+
 func TestBulkInserter_PersistentFailure_ReturnsBulkInsertError(t *testing.T) {
 	bc := &mockBroadcaster{
 		failNext: 100, // always fail


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced retry-backoff mechanism for broadcast failures with configurable delays when nodes are synchronizing, improving reliability during network catch-up events.

* **Tests**
  * Added comprehensive test coverage for catch-up retry scenarios and context deadline handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->