### PR TITLE
chore: add mainnet bridge identifiers to SDK validation

### DIFF
--- a/core/types/order_book_types.go
+++ b/core/types/order_book_types.go
@@ -162,15 +162,20 @@ type IOrderBook interface {
 
 // CreateMarketInput contains parameters for creating a new market
 type CreateMarketInput struct {
-	Bridge          string // Bridge namespace for collateral (hoodi_tt2, sepolia_bridge, ethereum_bridge)
+	Bridge          string // Bridge namespace for collateral (eth_usdc / eth_truf on mainnet; hoodi_tt2 / sepolia_bridge / ethereum_bridge on testnet)
 	QueryComponents []byte // ABI-encoded tuple: (address data_provider, bytes32 stream_id, string action_id, bytes args)
 	SettleTime      int64  // Unix timestamp when market can be settled (must be future)
 	MaxSpread       int    // Maximum spread for LP rewards (1-50 cents)
 	MinOrderSize    int64  // Minimum order size for LP rewards (must be positive)
 }
 
-// ValidBridges defines the supported bridge namespaces
+// ValidBridges defines the supported bridge namespaces.
+// eth_usdc (USDC) and eth_truf (TRUF) are the production mainnet bridges;
+// the others are testnet / legacy aliases retained for local-node and
+// integration test use. ethereum_bridge was the legacy mainnet TRUF bridge.
 var ValidBridges = map[string]bool{
+	"eth_usdc":        true,
+	"eth_truf":        true,
 	"hoodi_tt2":       true,
 	"sepolia_bridge":  true,
 	"ethereum_bridge": true,
@@ -183,7 +188,7 @@ func (c *CreateMarketInput) Validate() error {
 		return fmt.Errorf("bridge is required")
 	}
 	if !ValidBridges[c.Bridge] {
-		return fmt.Errorf("bridge must be one of: hoodi_tt2, sepolia_bridge, ethereum_bridge, got %s", c.Bridge)
+		return fmt.Errorf("bridge must be one of: eth_usdc, eth_truf, hoodi_tt2, sepolia_bridge, ethereum_bridge, got %s", c.Bridge)
 	}
 
 	// Validate query components

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2483,6 +2483,19 @@ if err != nil {
 
 The Bridge Actions Interface enables programmatic interaction with the TRUF.NETWORK bridge system. It allows bots and applications to manage token balances, initiate withdrawals to external chains (like Ethereum), and retrieve cryptographic proofs for claiming assets.
 
+#### Bridge identifiers — mainnet vs testnet
+
+| Identifier | Network | Token | Decimals | Notes |
+|---|---|---|---|---|
+| `eth_truf` | mainnet | TRUF | 18 | Used for protocol fees (stream write, attestation, market creation) |
+| `eth_usdc` | mainnet | USDC | 6 | Used for prediction-market collateral |
+| `ethereum_bridge` | mainnet | TRUF | 18 | Legacy — replaced by `eth_truf` |
+| `hoodi_tt` | testnet | TRUF (test) | 18 | Hoodi testnet |
+| `hoodi_tt2` | testnet | USDC (test) | 18 | Hoodi testnet — prediction-market collateral |
+| `sepolia_bridge` | testnet | TRUF (test) | 18 | Sepolia testnet, deprecated |
+
+Examples below use testnet identifiers; substitute the mainnet equivalent for production. Order-book actions (`create_market`, `place_buy_order`, etc.) accept `eth_usdc` or `eth_truf` as the `Bridge` parameter on mainnet.
+
 ### Core Methods
 
 These methods are available directly on the `Client` interface.


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new production mainnet bridges: `eth_usdc` and `eth_truf`.

* **Documentation**
  * Updated Bridge Actions Interface documentation with explicit identifier mapping tables for mainnet and testnet environments, clarifying supported bridge values and identifying legacy/deprecated identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->