### PR TITLE
chore: resume-able bulk inserter cathup

### DIFF
--- a/core/contractsapi/bulk_inserter.go
+++ b/core/contractsapi/bulk_inserter.go
@@ -58,12 +58,14 @@ type BulkInserter struct {
 	accountID   *kwiltypes.AccountID
 	logger      log.Logger
 
-	batchSize      int
-	maxInflight    int
-	maxAttempts    int
-	retryBackoff   time.Duration
-	catchupBackoff time.Duration
-	waitInterval   time.Duration
+	batchSize          int
+	maxInflight        int
+	maxAttempts        int
+	catchupMaxAttempts int
+	retryBackoff       time.Duration
+	catchupBackoff     time.Duration
+	waitInterval       time.Duration
+	progressLogEveryN  int
 
 	mu               sync.Mutex
 	pendingNonce     int64
@@ -95,12 +97,42 @@ func WithMaxInflight(n int) BulkInserterOption {
 }
 
 // WithMaxAttempts sets the maximum number of attempts per chunk (initial
-// attempt plus retries) on transient errors (invalid nonce, mempool full).
-// Default: 5.
+// attempt plus retries) on non-catchup transient errors (invalid nonce,
+// mempool full). Catch-up errors have their own budget — see
+// WithCatchupMaxAttempts. Default: 5.
 func WithMaxAttempts(n int) BulkInserterOption {
 	return func(b *BulkInserter) {
 		if n > 0 {
 			b.maxAttempts = n
+		}
+	}
+}
+
+// WithCatchupMaxAttempts sets the maximum number of attempts per chunk on
+// "node is catching up" rejections. Separate from WithMaxAttempts because
+// real catch-up events on the public RPC backend can run minutes long
+// (sentry replaying blocks after a peer flap or restart) while invalid-nonce
+// and mempool-full are typically resolved within seconds. Sharing one
+// budget would either fail too quickly on a real catch-up or waste
+// retries on a hopeless nonce. Default: 20.
+func WithCatchupMaxAttempts(n int) BulkInserterOption {
+	return func(b *BulkInserter) {
+		if n > 0 {
+			b.catchupMaxAttempts = n
+		}
+	}
+}
+
+// WithProgressLogEveryN enables INFO-level progress logging from InsertAll
+// every N chunks. Useful for long-running bulk loads where the operator
+// otherwise has no visibility between the "submitting" and "submitted"
+// log lines (which can be hours apart). Logs include chunks done / total,
+// rows done, elapsed time, current chunks/sec rate, and an ETA.
+// 0 disables progress logging. Default: 0.
+func WithProgressLogEveryN(n int) BulkInserterOption {
+	return func(b *BulkInserter) {
+		if n > 0 {
+			b.progressLogEveryN = n
 		}
 	}
 }
@@ -116,9 +148,14 @@ func WithRetryBackoff(d time.Duration) BulkInserterOption {
 }
 
 // WithCatchupBackoff sets the base backoff used when the broadcast backend
-// rejects with "node is catching up". Catch-up events typically resolve on
-// the order of tens of seconds, so this defaults higher than WithRetryBackoff.
-// Actual delay is catchupBackoff * (attempt + 1). Default: 5s.
+// rejects with "node is catching up". Catch-up events typically resolve in
+// tens of seconds (and occasionally minutes when a sentry is replaying
+// significant history), so this defaults much higher than WithRetryBackoff.
+// Actual delay is catchupBackoff * (attempt + 1). With the default of 15s
+// and WithCatchupMaxAttempts default 20, the worst-case wait per chunk is
+// 15+30+45+...+300s ≈ 52 minutes — comfortably long enough to ride out
+// every catch-up event seen in production so far without abandoning the
+// whole batch. Default: 15s.
 func WithCatchupBackoff(d time.Duration) BulkInserterOption {
 	return func(b *BulkInserter) {
 		if d > 0 {
@@ -176,16 +213,18 @@ func NewBulkInserter(
 	}
 
 	b := &BulkInserter{
-		broadcaster:    broadcaster,
-		txClient:       txClient,
-		accountID:      accountID,
-		logger:         log.DiscardLogger,
-		batchSize:      10,
-		maxInflight:    200,
-		maxAttempts:    5,
-		retryBackoff:   2 * time.Second,
-		catchupBackoff: 5 * time.Second,
-		waitInterval:   1 * time.Second,
+		broadcaster:        broadcaster,
+		txClient:           txClient,
+		accountID:          accountID,
+		logger:             log.DiscardLogger,
+		batchSize:          10,
+		maxInflight:        200,
+		maxAttempts:        5,
+		catchupMaxAttempts: 20,
+		retryBackoff:       2 * time.Second,
+		catchupBackoff:     15 * time.Second,
+		waitInterval:       1 * time.Second,
+		progressLogEveryN:  0,
 	}
 	for _, opt := range opts {
 		opt(b)
@@ -230,6 +269,12 @@ func (e *BulkInsertError) Unwrap() error {
 // Returns the tx hashes in submission order. On a chunk failure after
 // retries, returns the hashes broadcast so far plus a *BulkInsertError
 // indicating where to resume.
+//
+// When WithProgressLogEveryN(n>0) is set, emits an INFO log every n chunks
+// with chunks done / total / rate / ETA so operators have visibility into
+// long-running loads. Without it, the only logs are the WARN lines on
+// retry events (invalid nonce, mempool full, catching up) — which means
+// silence between start and finish, which may be hours apart.
 func (b *BulkInserter) InsertAll(
 	ctx context.Context,
 	inputs []sdktypes.InsertRecordInput,
@@ -241,6 +286,7 @@ func (b *BulkInserter) InsertAll(
 	chunks := chunkInputs(inputs, b.batchSize)
 	allHashes := make([]kwiltypes.Hash, 0, len(chunks))
 	inflight := make([]kwiltypes.Hash, 0, b.maxInflight)
+	start := time.Now()
 
 	for i, chunk := range chunks {
 		hash, err := b.broadcastWithRetry(ctx, chunk)
@@ -249,6 +295,10 @@ func (b *BulkInserter) InsertAll(
 		}
 		allHashes = append(allHashes, hash)
 		inflight = append(inflight, hash)
+
+		if b.progressLogEveryN > 0 && (i+1)%b.progressLogEveryN == 0 {
+			b.logProgress(i+1, len(chunks), start)
+		}
 
 		if len(inflight) >= b.maxInflight {
 			if err := b.drain(ctx, inflight); err != nil {
@@ -272,7 +322,33 @@ func (b *BulkInserter) InsertAll(
 		}
 	}
 
+	if b.progressLogEveryN > 0 {
+		b.logProgress(len(chunks), len(chunks), start)
+	}
+
 	return allHashes, nil
+}
+
+// logProgress emits a structured progress line. Best effort — the logger may
+// be DiscardLogger (the default) in which case this is a no-op besides the
+// time math, which is cheap.
+func (b *BulkInserter) logProgress(done, total int, start time.Time) {
+	elapsed := time.Since(start)
+	var chunksPerSec, etaSec float64
+	if elapsed.Seconds() > 0 {
+		chunksPerSec = float64(done) / elapsed.Seconds()
+	}
+	if chunksPerSec > 0 {
+		etaSec = float64(total-done) / chunksPerSec
+	}
+	b.logger.Info("bulk_inserter: progress",
+		"chunks_done", done,
+		"chunks_total", total,
+		"rows_done", done*b.batchSize,
+		"elapsed_sec", int(elapsed.Seconds()),
+		"chunks_per_sec", chunksPerSec,
+		"eta_sec", int(etaSec),
+	)
 }
 
 func (b *BulkInserter) broadcastWithRetry(
@@ -280,9 +356,10 @@ func (b *BulkInserter) broadcastWithRetry(
 	chunk []sdktypes.InsertRecordInput,
 ) (hash kwiltypes.Hash, retErr error) {
 	var (
-		lastErr     error
-		nonce       int64
-		nonceLoaded bool
+		nonce             int64
+		nonceLoaded       bool
+		transientAttempts int // counts ErrInvalidNonce + ErrMempoolFull tries
+		catchupAttempts   int // counts "node is catching up" tries
 	)
 	// On any error exit (attempt exhaustion, context cancellation during
 	// backoff, or an unhandled error), drop the cached nonce. The reserved
@@ -296,7 +373,7 @@ func (b *BulkInserter) broadcastWithRetry(
 			b.resetNonce()
 		}
 	}()
-	for attempt := 0; attempt < b.maxAttempts; attempt++ {
+	for {
 		// Pull a fresh nonce only on the first attempt OR after an
 		// ErrInvalidNonce reset. On ErrMempoolFull we keep the same nonce
 		// because the tx was rejected at admission — the mempool's
@@ -318,37 +395,53 @@ func (b *BulkInserter) broadcastWithRetry(
 			return hash, nil
 		}
 
-		lastErr = err
-
 		switch {
 		case errors.Is(err, kwiltypes.ErrInvalidNonce):
+			if transientAttempts+1 >= b.maxAttempts {
+				return kwiltypes.Hash{}, err
+			}
 			b.logger.Warn("bulk_inserter: invalid nonce, resetting cache",
-				"attempt", attempt+1, "nonce", nonce, "err", err)
+				"attempt", transientAttempts+1, "nonce", nonce, "err", err)
 			b.resetNonce()
 			nonceLoaded = false // force re-fetch on next attempt
-			if waitErr := b.backoff(ctx, attempt); waitErr != nil {
+			if waitErr := b.backoff(ctx, transientAttempts); waitErr != nil {
 				return kwiltypes.Hash{}, waitErr
 			}
+			transientAttempts++
 		case errors.Is(err, kwiltypes.ErrMempoolFull):
+			if transientAttempts+1 >= b.maxAttempts {
+				return kwiltypes.Hash{}, err
+			}
 			b.logger.Warn("bulk_inserter: mempool full, backing off",
-				"attempt", attempt+1, "nonce", nonce, "err", err)
+				"attempt", transientAttempts+1, "nonce", nonce, "err", err)
 			// Keep nonceLoaded=true so we retry with the same nonce.
-			if waitErr := b.backoff(ctx, attempt); waitErr != nil {
+			if waitErr := b.backoff(ctx, transientAttempts); waitErr != nil {
 				return kwiltypes.Hash{}, waitErr
 			}
+			transientAttempts++
 		case isCatchingUpErr(err):
+			// Catch-up gets its own larger budget — see WithCatchupMaxAttempts
+			// rationale. Real catch-up events on a public RPC backend (sentry
+			// replaying blocks after a peer flap) routinely run minutes long;
+			// sharing the transient budget here is what previously aborted
+			// 4-hour BulkInserter runs after just 75 seconds of waiting.
+			if catchupAttempts+1 >= b.catchupMaxAttempts {
+				return kwiltypes.Hash{}, err
+			}
 			b.logger.Warn("bulk_inserter: backend catching up, backing off",
-				"attempt", attempt+1, "nonce", nonce, "err", err)
+				"attempt", catchupAttempts+1,
+				"max_attempts", b.catchupMaxAttempts,
+				"nonce", nonce, "err", err)
 			// Keep nonceLoaded=true — the backend never admitted the tx, our
 			// cached nonce is still correct.
-			if waitErr := b.backoffCatchup(ctx, attempt); waitErr != nil {
+			if waitErr := b.backoffCatchup(ctx, catchupAttempts); waitErr != nil {
 				return kwiltypes.Hash{}, waitErr
 			}
+			catchupAttempts++
 		default:
 			return kwiltypes.Hash{}, err
 		}
 	}
-	return kwiltypes.Hash{}, lastErr
 }
 
 func (b *BulkInserter) backoff(ctx context.Context, attempt int) error {

--- a/core/contractsapi/bulk_inserter.go
+++ b/core/contractsapi/bulk_inserter.go
@@ -287,6 +287,7 @@ func (b *BulkInserter) InsertAll(
 	allHashes := make([]kwiltypes.Hash, 0, len(chunks))
 	inflight := make([]kwiltypes.Hash, 0, b.maxInflight)
 	start := time.Now()
+	rowsDone := 0
 
 	for i, chunk := range chunks {
 		hash, err := b.broadcastWithRetry(ctx, chunk)
@@ -295,9 +296,10 @@ func (b *BulkInserter) InsertAll(
 		}
 		allHashes = append(allHashes, hash)
 		inflight = append(inflight, hash)
+		rowsDone += len(chunk)
 
 		if b.progressLogEveryN > 0 && (i+1)%b.progressLogEveryN == 0 {
-			b.logProgress(i+1, len(chunks), start)
+			b.logProgress(i+1, len(chunks), rowsDone, start)
 		}
 
 		if len(inflight) >= b.maxInflight {
@@ -322,8 +324,11 @@ func (b *BulkInserter) InsertAll(
 		}
 	}
 
-	if b.progressLogEveryN > 0 {
-		b.logProgress(len(chunks), len(chunks), start)
+	// Skip the terminal log if the in-loop tick already covered the last
+	// chunk (i.e., len(chunks) is a multiple of progressLogEveryN); otherwise
+	// emit so operators always see one final line for the load.
+	if b.progressLogEveryN > 0 && len(chunks)%b.progressLogEveryN != 0 {
+		b.logProgress(len(chunks), len(chunks), rowsDone, start)
 	}
 
 	return allHashes, nil
@@ -331,8 +336,10 @@ func (b *BulkInserter) InsertAll(
 
 // logProgress emits a structured progress line. Best effort — the logger may
 // be DiscardLogger (the default) in which case this is a no-op besides the
-// time math, which is cheap.
-func (b *BulkInserter) logProgress(done, total int, start time.Time) {
+// time math, which is cheap. rowsDone is the cumulative count of input rows
+// actually broadcast so far (sum of len(chunk) over completed chunks), so a
+// partial final chunk doesn't get inflated to a full batchSize.
+func (b *BulkInserter) logProgress(done, total, rowsDone int, start time.Time) {
 	elapsed := time.Since(start)
 	var chunksPerSec, etaSec float64
 	if elapsed.Seconds() > 0 {
@@ -344,7 +351,7 @@ func (b *BulkInserter) logProgress(done, total int, start time.Time) {
 	b.logger.Info("bulk_inserter: progress",
 		"chunks_done", done,
 		"chunks_total", total,
-		"rows_done", done*b.batchSize,
+		"rows_done", rowsDone,
 		"elapsed_sec", int(elapsed.Seconds()),
 		"chunks_per_sec", chunksPerSec,
 		"eta_sec", int(etaSec),

--- a/core/contractsapi/bulk_inserter.go
+++ b/core/contractsapi/bulk_inserter.go
@@ -99,7 +99,7 @@ func WithMaxInflight(n int) BulkInserterOption {
 // WithMaxAttempts sets the maximum number of attempts per chunk (initial
 // attempt plus retries) on non-catchup transient errors (invalid nonce,
 // mempool full). Catch-up errors have their own budget — see
-// WithCatchupMaxAttempts. Default: 5.
+// WithCatchupMaxAttempts. Default: 15.
 func WithMaxAttempts(n int) BulkInserterOption {
 	return func(b *BulkInserter) {
 		if n > 0 {
@@ -219,7 +219,12 @@ func NewBulkInserter(
 		logger:             log.DiscardLogger,
 		batchSize:          10,
 		maxInflight:        200,
-		maxAttempts:        5,
+		// 15 transient attempts (invalid nonce / mempool full) is the lowest
+		// default that handles a thousand-chunk insert running through brief
+		// mempool congestion without bottlenecking on the adapter resume layer
+		// above (which only gets 5 partial-progress passes). With linear backoff
+		// of 2s, that's ~4 minutes of waiting per chunk before bubbling up.
+		maxAttempts:        15,
 		catchupMaxAttempts: 20,
 		retryBackoff:       2 * time.Second,
 		catchupBackoff:     15 * time.Second,

--- a/core/contractsapi/bulk_inserter.go
+++ b/core/contractsapi/bulk_inserter.go
@@ -152,10 +152,11 @@ func WithRetryBackoff(d time.Duration) BulkInserterOption {
 // tens of seconds (and occasionally minutes when a sentry is replaying
 // significant history), so this defaults much higher than WithRetryBackoff.
 // Actual delay is catchupBackoff * (attempt + 1). With the default of 15s
-// and WithCatchupMaxAttempts default 20, the worst-case wait per chunk is
-// 15+30+45+...+300s ≈ 52 minutes — comfortably long enough to ride out
-// every catch-up event seen in production so far without abandoning the
-// whole batch. Default: 15s.
+// and WithCatchupMaxAttempts default 20, the loop runs 20 attempts with 19
+// sleeps in between (the 20th attempt's failure exits before backing off),
+// so the worst-case wait per chunk is 15+30+45+...+285s = 2850s ≈ 47.5
+// minutes — comfortably long enough to ride out every catch-up event seen
+// in production so far without abandoning the whole batch. Default: 15s.
 func WithCatchupBackoff(d time.Duration) BulkInserterOption {
 	return func(b *BulkInserter) {
 		if d > 0 {

--- a/core/contractsapi/bulk_inserter_test.go
+++ b/core/contractsapi/bulk_inserter_test.go
@@ -1,10 +1,12 @@
 package contractsapi_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,6 +17,7 @@ import (
 	kwilclient "github.com/trufnetwork/kwil-db/core/client/types"
 	"github.com/trufnetwork/kwil-db/core/crypto"
 	"github.com/trufnetwork/kwil-db/core/crypto/auth"
+	kwillog "github.com/trufnetwork/kwil-db/core/log"
 	kwiltypes "github.com/trufnetwork/kwil-db/core/types"
 	"github.com/trufnetwork/sdk-go/core/contractsapi"
 	sdktypes "github.com/trufnetwork/sdk-go/core/types"
@@ -475,4 +478,116 @@ func TestBulkInserter_PassesNonceAndSyncBroadcastOpts(t *testing.T) {
 	require.Len(t, calls, 1)
 	assert.Equal(t, int64(201), calls[0].nonce)
 	assert.False(t, calls[0].syncBcast, "BulkInserter must always set SyncBroadcast=false")
+}
+
+// TestBulkInserter_CatchingUp_HasSeparateBudget pins the design split: a low
+// WithMaxAttempts must not abort during a long catch-up, because catch-up has
+// its own larger budget via WithCatchupMaxAttempts. Without the split, the
+// 2026-04-25 incident reproduces — catch-up sharing the 5-attempt transient
+// budget aborted multi-hour bulk loads after 75 seconds of waiting.
+func TestBulkInserter_CatchingUp_HasSeparateBudget(t *testing.T) {
+	bc := &mockBroadcaster{
+		failNext: 6, // > maxAttempts (3) but < catchupMaxAttempts (10)
+		failErr:  errors.New("broadcast error: code 65535: node is catching up, cannot process transactions right now"),
+	}
+	tc := &mockTxClient{ledgerNonce: 50}
+	bi, err := contractsapi.NewBulkInserter(bc, tc, newTestSigner(t),
+		contractsapi.WithMaxAttempts(3),                  // small generic budget
+		contractsapi.WithCatchupMaxAttempts(10),          // larger catch-up budget
+		contractsapi.WithCatchupBackoff(1*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	hashes, err := bi.InsertAll(context.Background(), makeInputs(10))
+	require.NoError(t, err, "should succeed: 6 catch-up failures fit in catchupMaxAttempts=10 even though > maxAttempts=3")
+	assert.Len(t, hashes, 1)
+	assert.Len(t, bc.snapshot(), 7, "should retry until success on the 7th attempt")
+}
+
+// TestBulkInserter_CatchingUp_BudgetCap verifies the catch-up budget is
+// honored — once exceeded, the chunk fails with the catch-up error.
+func TestBulkInserter_CatchingUp_BudgetCap(t *testing.T) {
+	bc := &mockBroadcaster{
+		failNext: 100,
+		failErr:  errors.New("broadcast error: node is catching up, cannot process transactions right now"),
+	}
+	tc := &mockTxClient{ledgerNonce: 50}
+	bi, err := contractsapi.NewBulkInserter(bc, tc, newTestSigner(t),
+		contractsapi.WithMaxAttempts(100),
+		contractsapi.WithCatchupMaxAttempts(3),
+		contractsapi.WithCatchupBackoff(1*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	_, err = bi.InsertAll(context.Background(), makeInputs(10))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node is catching up")
+	assert.Len(t, bc.snapshot(), 3, "should stop at catchupMaxAttempts attempts")
+}
+
+// TestBulkInserter_ProgressLogging emits the periodic progress line at the
+// configured cadence and on the final iteration, so operators always see at
+// least one terminal log line for any non-empty load.
+func TestBulkInserter_ProgressLogging(t *testing.T) {
+	bc := &mockBroadcaster{}
+	tc := &mockTxClient{ledgerNonce: 0}
+	var buf threadSafeBuffer
+	logger := kwillog.New(kwillog.WithWriter(&buf), kwillog.WithLevel(kwillog.LevelInfo))
+	bi, err := contractsapi.NewBulkInserter(bc, tc, newTestSigner(t),
+		contractsapi.WithBatchSize(10),
+		contractsapi.WithProgressLogEveryN(2),
+		contractsapi.WithLogger(logger),
+	)
+	require.NoError(t, err)
+
+	// 50 inputs / batchSize 10 = 5 chunks. With everyN=2: ticks at chunks
+	// 2 and 4 from the in-loop check, plus one final tick at chunk 5 from
+	// the post-loop emit. Total 3 progress lines.
+	_, err = bi.InsertAll(context.Background(), makeInputs(50))
+	require.NoError(t, err)
+
+	progressLines := strings.Count(buf.String(), "bulk_inserter: progress")
+	assert.Equal(t, 3, progressLines, "expected 3 progress emits (chunks 2, 4, and final 5)")
+	assert.Contains(t, buf.String(), "rows_done=20", "should report rows_done")
+	assert.Contains(t, buf.String(), "chunks_total=5", "should report chunks_total")
+}
+
+// TestBulkInserter_ProgressLogging_DisabledByDefault confirms the default
+// configuration emits no progress lines (back-compat).
+func TestBulkInserter_ProgressLogging_DisabledByDefault(t *testing.T) {
+	bc := &mockBroadcaster{}
+	tc := &mockTxClient{ledgerNonce: 0}
+	var buf threadSafeBuffer
+	logger := kwillog.New(kwillog.WithWriter(&buf), kwillog.WithLevel(kwillog.LevelInfo))
+	bi, err := contractsapi.NewBulkInserter(bc, tc, newTestSigner(t),
+		contractsapi.WithLogger(logger),
+		// no WithProgressLogEveryN
+	)
+	require.NoError(t, err)
+
+	_, err = bi.InsertAll(context.Background(), makeInputs(50))
+	require.NoError(t, err)
+
+	assert.NotContains(t, buf.String(), "bulk_inserter: progress",
+		"no progress lines without WithProgressLogEveryN")
+}
+
+// threadSafeBuffer wraps bytes.Buffer with a mutex — the kwil-db logger writes
+// from multiple goroutines if used concurrently, and bytes.Buffer is not safe
+// for concurrent writes.
+type threadSafeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *threadSafeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *threadSafeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/core/contractsapi/bulk_inserter_test.go
+++ b/core/contractsapi/bulk_inserter_test.go
@@ -572,6 +572,59 @@ func TestBulkInserter_ProgressLogging_DisabledByDefault(t *testing.T) {
 		"no progress lines without WithProgressLogEveryN")
 }
 
+// TestBulkInserter_ProgressLogging_PartialLastChunk verifies that rows_done
+// counts the actual number of rows broadcast (not chunks*batchSize), so a
+// partial last chunk doesn't get inflated to a full batchSize. Regression
+// guard against the off-by-some count where 25 rows / 10 batch reported 30.
+func TestBulkInserter_ProgressLogging_PartialLastChunk(t *testing.T) {
+	bc := &mockBroadcaster{}
+	tc := &mockTxClient{ledgerNonce: 0}
+	var buf threadSafeBuffer
+	logger := kwillog.New(kwillog.WithWriter(&buf), kwillog.WithLevel(kwillog.LevelInfo))
+	bi, err := contractsapi.NewBulkInserter(bc, tc, newTestSigner(t),
+		contractsapi.WithBatchSize(10),
+		contractsapi.WithProgressLogEveryN(10), // never trips the in-loop tick
+		contractsapi.WithLogger(logger),
+	)
+	require.NoError(t, err)
+
+	// 25 inputs / batchSize 10 = 3 chunks (10, 10, 5). Only the final
+	// post-loop emit fires; it must report rows_done=25, not 30.
+	_, err = bi.InsertAll(context.Background(), makeInputs(25))
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Equal(t, 1, strings.Count(out, "bulk_inserter: progress"),
+		"only the final post-loop emit should fire")
+	assert.Contains(t, out, "rows_done=25", "must report actual rows broadcast, not chunks*batchSize")
+	assert.NotContains(t, out, "rows_done=30", "must not overcount partial last chunk")
+}
+
+// TestBulkInserter_ProgressLogging_NoDuplicateFinal verifies the final
+// post-loop emit is suppressed when the last chunk index is already a
+// multiple of progressLogEveryN — otherwise the same line gets logged twice.
+func TestBulkInserter_ProgressLogging_NoDuplicateFinal(t *testing.T) {
+	bc := &mockBroadcaster{}
+	tc := &mockTxClient{ledgerNonce: 0}
+	var buf threadSafeBuffer
+	logger := kwillog.New(kwillog.WithWriter(&buf), kwillog.WithLevel(kwillog.LevelInfo))
+	bi, err := contractsapi.NewBulkInserter(bc, tc, newTestSigner(t),
+		contractsapi.WithBatchSize(10),
+		contractsapi.WithProgressLogEveryN(2),
+		contractsapi.WithLogger(logger),
+	)
+	require.NoError(t, err)
+
+	// 20 inputs / batchSize 10 = 2 chunks. With everyN=2, the in-loop
+	// tick fires at chunk 2; the post-loop emit must NOT fire (would
+	// duplicate). Expected total: 1 line.
+	_, err = bi.InsertAll(context.Background(), makeInputs(20))
+	require.NoError(t, err)
+
+	progressLines := strings.Count(buf.String(), "bulk_inserter: progress")
+	assert.Equal(t, 1, progressLines, "expected single emit (in-loop only); post-loop must skip when the last chunk was already logged")
+}
+
 // threadSafeBuffer wraps bytes.Buffer with a mutex — the kwil-db logger writes
 // from multiple goroutines if used concurrently, and bytes.Buffer is not safe
 // for concurrent writes.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1211,17 +1211,25 @@ gateway client, and signer. Requires HTTP transport.
 ##### Options
 
 ```go
-contractsapi.WithBatchSize(n int)                // records per tx; default 10 (protocol cap)
-contractsapi.WithMaxInflight(n int)              // broadcasts queued before forced drain; default 200
-contractsapi.WithMaxAttempts(n int)              // initial + retries per chunk on transient errors
-                                                 // (invalid nonce, mempool full, "node is catching up"); default 5
-contractsapi.WithRetryBackoff(d time.Duration)   // base backoff for invalid-nonce / mempool-full;
-                                                 // actual delay = backoff * (attempt + 1); default 2s
-contractsapi.WithCatchupBackoff(d time.Duration) // base backoff when the broadcast backend rejects with
-                                                 // "node is catching up" (typically resolves in tens of seconds);
-                                                 // actual delay = backoff * (attempt + 1); default 5s
-contractsapi.WithWaitInterval(d time.Duration)   // polling interval for WaitTx during drain; default 1s
-contractsapi.WithLogger(log.Logger)              // structured logger; default discard
+contractsapi.WithBatchSize(n int)                  // records per tx; default 10 (protocol cap)
+contractsapi.WithMaxInflight(n int)                // broadcasts queued before forced drain; default 200
+contractsapi.WithMaxAttempts(n int)                // initial + retries per chunk on non-catchup transient
+                                                   // errors (invalid nonce, mempool full); default 15
+contractsapi.WithCatchupMaxAttempts(n int)         // initial + retries per chunk on "node is catching up"
+                                                   // rejections (separate budget from above because catch-up
+                                                   // events on a public RPC routinely run minutes long);
+                                                   // default 20
+contractsapi.WithRetryBackoff(d time.Duration)     // base backoff for invalid-nonce / mempool-full;
+                                                   // actual delay = backoff * (attempt + 1); default 2s
+contractsapi.WithCatchupBackoff(d time.Duration)   // base backoff when the backend rejects with "node is
+                                                   // catching up"; actual delay = backoff * (attempt + 1).
+                                                   // With default 15s and CatchupMaxAttempts=20, worst-case
+                                                   // wait per chunk is 15+30+...+300s ≈ 52 min; default 15s
+contractsapi.WithProgressLogEveryN(n int)          // emit INFO progress line every N chunks (chunks done /
+                                                   // total, rows done, elapsed, chunks/sec, ETA);
+                                                   // 0 disables; default 0
+contractsapi.WithWaitInterval(d time.Duration)     // polling interval for WaitTx during drain; default 1s
+contractsapi.WithLogger(log.Logger)                // structured logger; default discard
 ```
 
 #### `InsertAll`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1223,8 +1223,10 @@ contractsapi.WithRetryBackoff(d time.Duration)     // base backoff for invalid-n
                                                    // actual delay = backoff * (attempt + 1); default 2s
 contractsapi.WithCatchupBackoff(d time.Duration)   // base backoff when the backend rejects with "node is
                                                    // catching up"; actual delay = backoff * (attempt + 1).
-                                                   // With default 15s and CatchupMaxAttempts=20, worst-case
-                                                   // wait per chunk is 15+30+...+300s ≈ 52 min; default 15s
+                                                   // With default 15s and CatchupMaxAttempts=20, the loop
+                                                   // does 20 attempts with 19 backoffs (the last attempt
+                                                   // fails without sleeping), so worst-case wait per chunk
+                                                   // is 15+30+...+285s ≈ 47.5 min; default 15s
 contractsapi.WithProgressLogEveryN(n int)          // emit INFO progress line every N chunks (chunks done /
                                                    // total, rows done, elapsed, chunks/sec, ETA);
                                                    // 0 disables; default 0

--- a/tests/integration/server_fixture.go
+++ b/tests/integration/server_fixture.go
@@ -93,11 +93,24 @@ func NewServerFixture(t *testing.T) *ServerFixture {
 				tmpfsPath: "/var/lib/postgresql/data",
 				portsMap:  map[string]string{"5432": "5432"},
 				envVars:   []string{"POSTGRES_HOST_AUTH_METHOD=trust"},
-				// kwild's postgres validator now requires max_prepared_transactions >= 200.
-				// kwildb/postgres:latest defaults to 2, so the kwild process exits before
-				// the tn-db container becomes healthy. Override at the command line so we
-				// can keep the floating tag and pick up future image updates automatically.
-				command: []string{"postgres", "-c", "max_prepared_transactions=200"},
+				// kwild validates a set of postgres settings at startup
+				// (kwil-db/node/pg/system.go: settingValidations) and exits
+				// before the tn-db container becomes healthy if any are off.
+				// We override every non-default it requires here so we can keep
+				// the floating :latest tag instead of pinning around image
+				// regressions. Defensive: max_wal_senders/max_replication_slots
+				// are PG16 defaults (10) but pinned in case a future image
+				// lowers them. Other validated settings (synchronous_commit,
+				// fsync, array_nulls, idle_in_transaction_timeout=0, server
+				// encoding, etc.) are postgres defaults already.
+				command: []string{
+					"postgres",
+					"-c", "wal_level=logical",
+					"-c", "max_wal_senders=10",
+					"-c", "max_replication_slots=10",
+					"-c", "max_prepared_transactions=200",
+					"-c", "wal_sender_timeout=0",
+				},
 				healthCheck: func(d *docker) error {
 					_, err := d.exec("test-kwil-postgres", "pg_isready", "-U", "postgres")
 					return err

--- a/tests/integration/server_fixture.go
+++ b/tests/integration/server_fixture.go
@@ -76,6 +76,17 @@ func NewServerFixture(t *testing.T) *ServerFixture {
 	}
 	t.Logf("Using TN-DB Docker image: %s", tndbImage)
 
+	// Get Postgres Docker image from environment, default to upstream latest.
+	// Set POSTGRES_IMAGE=kwildb/postgres:16.8-2 (or similar tag) to pin against
+	// upstream regressions for a CI run; the command-line settings overrides
+	// below are written so the container works against any kwildb/postgres
+	// version that ships PG16+.
+	postgresImage := os.Getenv("POSTGRES_IMAGE")
+	if postgresImage == "" {
+		postgresImage = "kwildb/postgres:latest"
+	}
+	t.Logf("Using Postgres Docker image: %s", postgresImage)
+
 	return &ServerFixture{
 		t:                 t,
 		docker:            d,
@@ -89,7 +100,7 @@ func NewServerFixture(t *testing.T) *ServerFixture {
 		}{
 			postgres: containerSpec{
 				name:      "test-kwil-postgres",
-				image:     "kwildb/postgres:latest",
+				image:     postgresImage,
 				tmpfsPath: "/var/lib/postgresql/data",
 				portsMap:  map[string]string{"5432": "5432"},
 				envVars:   []string{"POSTGRES_HOST_AUTH_METHOD=trust"},

--- a/tests/integration/server_fixture.go
+++ b/tests/integration/server_fixture.go
@@ -93,6 +93,11 @@ func NewServerFixture(t *testing.T) *ServerFixture {
 				tmpfsPath: "/var/lib/postgresql/data",
 				portsMap:  map[string]string{"5432": "5432"},
 				envVars:   []string{"POSTGRES_HOST_AUTH_METHOD=trust"},
+				// kwild's postgres validator now requires max_prepared_transactions >= 200.
+				// kwildb/postgres:latest defaults to 2, so the kwild process exits before
+				// the tn-db container becomes healthy. Override at the command line so we
+				// can keep the floating tag and pick up future image updates automatically.
+				command: []string{"postgres", "-c", "max_prepared_transactions=200"},
 				healthCheck: func(d *docker) error {
 					_, err := d.exec("test-kwil-postgres", "pg_isready", "-U", "postgres")
 					return err


### PR DESCRIPTION
resolves: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable catch-up retry budget for better handling when a node is catching up
  * Optional progress logging for bulk insert operations (configurable interval; off by default)
  * Improved retry behavior: separate handling for transient errors vs catch-up scenarios, allowing longer catch-up retries

* **Documentation**
  * Updated docs to reflect new defaults and new retry/logging options

* **Tests**
  * Added tests covering retry budgeting and progress-logging behavior; updated test DB fixture startup settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->