### PR TITLE
feat: deploy and configure streams to allow 0 value

### DIFF
--- a/core/contractsapi/abstract_api.go
+++ b/core/contractsapi/abstract_api.go
@@ -202,6 +202,41 @@ func (s *Action) SetDefaultBaseTime(ctx context.Context, input types.DefaultBase
 	})
 }
 
+// SetAllowZeros toggles the per-stream allow_zeros flag via the
+// dedicated set_allow_zeros action (which atomically disables any prior
+// row and writes a fresh one when value=true). Owner-gated on the node.
+func (s *Action) SetAllowZeros(ctx context.Context, locator types.StreamLocator, value bool) (kwiltypes.Hash, error) {
+	return s.execute(ctx, "set_allow_zeros", [][]any{{
+		locator.DataProvider.Address(),
+		locator.StreamId.String(),
+		value,
+	}})
+}
+
+// GetAllowZeros returns the latest allow_zeros setting for the stream.
+// Returns false when the stream has no explicit metadata row, matching
+// the implicit default applied at insert time.
+func (s *Action) GetAllowZeros(ctx context.Context, locator types.StreamLocator) (bool, error) {
+	result, err := s.call(ctx, "get_allow_zeros", []any{
+		locator.DataProvider.Address(),
+		locator.StreamId.String(),
+	})
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	if len(result.Values) == 0 || len(result.Values[0]) == 0 {
+		return false, nil
+	}
+	switch v := result.Values[0][0].(type) {
+	case bool:
+		return v, nil
+	case nil:
+		return false, nil
+	default:
+		return false, errors.Errorf("get_allow_zeros: unexpected value type %T", v)
+	}
+}
+
 var MetadataValueNotFound = errors.New("metadata value not found")
 
 type DisableMetadataByRefInput struct {
@@ -211,6 +246,10 @@ type DisableMetadataByRefInput struct {
 }
 
 func (s *Action) disableMetadataByRef(ctx context.Context, input DisableMetadataByRefInput) (kwiltypes.Hash, error) {
+	if input.Key == types.AllowZerosKey {
+		return kwiltypes.Hash{}, errors.Wrapf(ErrReservedMetadataKey, "%s", input.Key.String())
+	}
+
 	metadataList, err := s.getMetadata(ctx, getMetadataParams{
 		Stream:  input.Stream,
 		Key:     input.Key,

--- a/core/contractsapi/allow_zeros_guard_test.go
+++ b/core/contractsapi/allow_zeros_guard_test.go
@@ -1,0 +1,80 @@
+package contractsapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/trufnetwork/sdk-go/core/types"
+	"github.com/trufnetwork/sdk-go/core/util"
+)
+
+// TestInsertMetadata_RejectsAllowZerosKey locks in the client-side
+// guard that mirrors the node-side reservation: routing AllowZerosKey
+// through the generic insertMetadata helper would let two parallel
+// "latest" rows coexist and break the disable-then-insert atomicity
+// that SetAllowZeros / set_allow_zeros own. We catch this at the SDK
+// layer for a friendlier error than the eventual "use set_allow_zeros"
+// from the node.
+func TestInsertMetadata_RejectsAllowZerosKey(t *testing.T) {
+	action := &Action{}
+
+	streamId, err := util.NewStreamId("st00000000000000000000000000aabb")
+	require.NoError(t, err)
+	dp, err := util.NewEthereumAddressFromString("0x000000000000000000000000000000000000a110")
+	require.NoError(t, err)
+
+	_, err = action.insertMetadata(context.Background(), InsertMetadataInput{
+		Stream: types.StreamLocator{StreamId: *streamId, DataProvider: dp},
+		Key:    types.AllowZerosKey,
+		Value:  types.NewMetadataValue(true),
+	})
+
+	require.Error(t, err, "insertMetadata must reject reserved key")
+	require.True(t, errors.Is(err, ErrReservedMetadataKey),
+		"error must wrap ErrReservedMetadataKey so callers can branch on it")
+	require.Contains(t, err.Error(), "allow_zeros",
+		"error message must name the offending key")
+}
+
+// TestDisableMetadataByRef_RejectsAllowZerosKey covers the dual path:
+// disabling by ref skips the metadata lookup if the key is reserved,
+// matching the insertMetadata guard so neither shortcut bypasses the
+// dedicated SetAllowZeros mutator.
+func TestDisableMetadataByRef_RejectsAllowZerosKey(t *testing.T) {
+	action := &Action{}
+
+	streamId, err := util.NewStreamId("st00000000000000000000000000aabb")
+	require.NoError(t, err)
+	dp, err := util.NewEthereumAddressFromString("0x000000000000000000000000000000000000a110")
+	require.NoError(t, err)
+
+	_, err = action.disableMetadataByRef(context.Background(), DisableMetadataByRefInput{
+		Stream: types.StreamLocator{StreamId: *streamId, DataProvider: dp},
+		Key:    types.AllowZerosKey,
+		Ref:    "anything",
+	})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrReservedMetadataKey))
+}
+
+// TestInsertMetadata_AllowsOtherKeys is a guardrail for the guard
+// itself: a regression that broadens the rejection to any metadata key
+// would brick the existing typed wrappers (SetReadVisibility, etc.).
+// We don't actually execute the call (no live node here) — we just
+// confirm the guard doesn't trip for non-reserved keys before the
+// helper attempts its execute.
+func TestInsertMetadata_AllowsOtherKeys(t *testing.T) {
+	for _, key := range []types.MetadataKey{
+		types.ReadVisibilityKey,
+		types.ComposeVisibilityKey,
+		types.AllowReadWalletKey,
+	} {
+		t.Run(string(key), func(t *testing.T) {
+			require.NotEqual(t, types.AllowZerosKey, key,
+				"non-reserved keys must not trip the AllowZerosKey guard")
+		})
+	}
+}

--- a/core/contractsapi/allow_zeros_guard_test.go
+++ b/core/contractsapi/allow_zeros_guard_test.go
@@ -63,18 +63,52 @@ func TestDisableMetadataByRef_RejectsAllowZerosKey(t *testing.T) {
 // TestInsertMetadata_AllowsOtherKeys is a guardrail for the guard
 // itself: a regression that broadens the rejection to any metadata key
 // would brick the existing typed wrappers (SetReadVisibility, etc.).
-// We don't actually execute the call (no live node here) — we just
-// confirm the guard doesn't trip for non-reserved keys before the
-// helper attempts its execute.
+// For each non-reserved key we actually invoke the helper and require
+// that it gets PAST the guard. The follow-on s.execute call has a nil
+// _client and panics — that panic is the proof the guard let us through.
+// What matters is no ErrReservedMetadataKey is returned for a non-reserved key.
 func TestInsertMetadata_AllowsOtherKeys(t *testing.T) {
-	for _, key := range []types.MetadataKey{
-		types.ReadVisibilityKey,
-		types.ComposeVisibilityKey,
-		types.AllowReadWalletKey,
-	} {
-		t.Run(string(key), func(t *testing.T) {
-			require.NotEqual(t, types.AllowZerosKey, key,
-				"non-reserved keys must not trip the AllowZerosKey guard")
+	streamId, err := util.NewStreamId("st00000000000000000000000000aabb")
+	require.NoError(t, err)
+	dp, err := util.NewEthereumAddressFromString("0x000000000000000000000000000000000000a110")
+	require.NoError(t, err)
+
+	cases := []struct {
+		key types.MetadataKey
+		val types.MetadataValue
+	}{
+		{types.ReadVisibilityKey, types.NewMetadataValue(0)},
+		{types.ComposeVisibilityKey, types.NewMetadataValue(0)},
+		{types.AllowReadWalletKey, types.NewMetadataValue("0x0000000000000000000000000000000000000001")},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.key), func(t *testing.T) {
+			action := &Action{}
+			tripped := callInsertMetadataChecked(t, action, types.StreamLocator{
+				StreamId: *streamId, DataProvider: dp,
+			}, tc.key, tc.val)
+			require.False(t, tripped, "guard must not trip for non-reserved key %s", tc.key)
 		})
 	}
+}
+
+// callInsertMetadataChecked invokes insertMetadata against an Action with
+// no client and returns whether ErrReservedMetadataKey was raised. The
+// nil-client panic past the guard is treated as "guard passed" since
+// the test's only concern is which keys the guard rejects.
+func callInsertMetadataChecked(t *testing.T, action *Action, stream types.StreamLocator, key types.MetadataKey, val types.MetadataValue) (tripped bool) {
+	t.Helper()
+	defer func() {
+		_ = recover() // nil _client deref past the guard — expected
+	}()
+	_, err := action.insertMetadata(context.Background(), InsertMetadataInput{
+		Stream: stream,
+		Key:    key,
+		Value:  val,
+	})
+	if err != nil && errors.Is(err, ErrReservedMetadataKey) {
+		tripped = true
+	}
+	return tripped
 }

--- a/core/contractsapi/batch_deploy_streams.go
+++ b/core/contractsapi/batch_deploy_streams.go
@@ -47,18 +47,16 @@ func BatchDeployStreams(ctx context.Context, input BatchDeployStreamsInput) (kwi
 		}
 	}
 
-	// Always pass the allow_zeros array so the action signature stays
-	// stable for callers; if no stream opted in, the action's IS NOT NULL
-	// branch still skips the metadata write because every entry is FALSE.
-	var args [][]any
+	// Omit the allow_zeros argument entirely when no stream opted in so
+	// the on-the-wire payload stays compatible with pre-feature nodes
+	// that haven't been upgraded. Only append the third array when at
+	// least one stream needs it, in which case the node must be on the
+	// migration that added $allow_zeros.
+	inner := []any{streamIds, streamTypes}
 	if anyAllowZeros {
-		args = [][]any{{streamIds, streamTypes, allowZeros}}
-	} else {
-		// Pass nil for the third arg so create_streams takes the
-		// DEFAULT NULL path and writes zero metadata rows. Equivalent
-		// to omitting the arg, but keeps the call shape uniform.
-		args = [][]any{{streamIds, streamTypes, nil}}
+		inner = append(inner, allowZeros)
 	}
+	args := [][]any{inner}
 
 	txHash, err := input.KwilClient.Execute(ctx, input.SchemaName, "create_streams", args, kwilClientType.WithNonce(0))
 	if err != nil {

--- a/core/contractsapi/batch_deploy_streams.go
+++ b/core/contractsapi/batch_deploy_streams.go
@@ -22,6 +22,12 @@ type BatchDeployStreamsInput struct {
 // BatchDeployStreams deploys multiple streams by calling the create_streams SQL action.
 // It returns the transaction hash of the batch operation and an error if the submission fails.
 // Waiting for the transaction and parsing individual results should be handled separately.
+//
+// Each StreamDefinition.AllowZeros (default false) controls per-stream
+// persistence of value=0 inserts. The fourth array argument to
+// create_streams is omitted entirely when every stream uses the default
+// (false), keeping the on-the-wire payload compatible with pre-feature
+// nodes that haven't been upgraded.
 func BatchDeployStreams(ctx context.Context, input BatchDeployStreamsInput) (kwilType.Hash, error) {
 	if len(input.Definitions) == 0 {
 		return kwilType.Hash{}, errors.New("no stream definitions provided for batch deployment")
@@ -29,14 +35,30 @@ func BatchDeployStreams(ctx context.Context, input BatchDeployStreamsInput) (kwi
 
 	streamIds := make([]string, len(input.Definitions))
 	streamTypes := make([]string, len(input.Definitions))
+	allowZeros := make([]bool, len(input.Definitions))
+	anyAllowZeros := false
 
 	for i, def := range input.Definitions {
 		streamIds[i] = def.StreamId.String()
-		streamTypes[i] = string(def.StreamType) // Assuming StreamType is string or has String() method
+		streamTypes[i] = string(def.StreamType)
+		allowZeros[i] = def.AllowZeros
+		if def.AllowZeros {
+			anyAllowZeros = true
+		}
 	}
 
-	// The create_streams procedure expects two array arguments: $stream_ids TEXT[], $stream_types TEXT[]
-	args := [][]any{{streamIds, streamTypes}}
+	// Always pass the allow_zeros array so the action signature stays
+	// stable for callers; if no stream opted in, the action's IS NOT NULL
+	// branch still skips the metadata write because every entry is FALSE.
+	var args [][]any
+	if anyAllowZeros {
+		args = [][]any{{streamIds, streamTypes, allowZeros}}
+	} else {
+		// Pass nil for the third arg so create_streams takes the
+		// DEFAULT NULL path and writes zero metadata rows. Equivalent
+		// to omitting the arg, but keeps the call shape uniform.
+		args = [][]any{{streamIds, streamTypes, nil}}
+	}
 
 	txHash, err := input.KwilClient.Execute(ctx, input.SchemaName, "create_streams", args, kwilClientType.WithNonce(0))
 	if err != nil {

--- a/core/contractsapi/deploy_stream.go
+++ b/core/contractsapi/deploy_stream.go
@@ -21,10 +21,19 @@ type DeployStreamInput struct {
 }
 
 // DeployStream deploys a stream to TN.
+//
+// When AllowZeros is false (the default), only the legacy two arguments
+// are sent so the call shape matches pre-feature nodes that haven't
+// learned about $allow_zeros. The third argument is appended only when
+// the caller opts in, in which case the node must be on the migration
+// that added the parameter.
 func DeployStream(ctx context.Context, input DeployStreamInput) (kwilTypes.Hash, error) {
-	return input.KwilClient.Execute(ctx, "", "create_stream", [][]any{{
+	args := []any{
 		input.StreamId.String(),
 		input.StreamType.String(),
-		input.AllowZeros,
-	}})
+	}
+	if input.AllowZeros {
+		args = append(args, input.AllowZeros)
+	}
+	return input.KwilClient.Execute(ctx, "", "create_stream", [][]any{args})
 }

--- a/core/contractsapi/deploy_stream.go
+++ b/core/contractsapi/deploy_stream.go
@@ -2,6 +2,7 @@ package contractsapi
 
 import (
 	"context"
+
 	"github.com/trufnetwork/kwil-db/core/gatewayclient"
 	kwilTypes "github.com/trufnetwork/kwil-db/core/types"
 	"github.com/trufnetwork/sdk-go/core/types"
@@ -13,12 +14,17 @@ type DeployStreamInput struct {
 	StreamType types.StreamType             `validate:"required"`
 	KwilClient *gatewayclient.GatewayClient `validate:"required"`
 	Deployer   []byte                       `validate:"required"`
+	// AllowZeros, when true, opts the new stream out of the value=0 insert
+	// filter so zero-valued records persist and surface in get_record. When
+	// false (default), zeros are dropped at insert time — today's behavior.
+	AllowZeros bool
 }
 
-// DeployStream deploys a stream to TN
+// DeployStream deploys a stream to TN.
 func DeployStream(ctx context.Context, input DeployStreamInput) (kwilTypes.Hash, error) {
 	return input.KwilClient.Execute(ctx, "", "create_stream", [][]any{{
 		input.StreamId.String(),
 		input.StreamType.String(),
+		input.AllowZeros,
 	}})
 }

--- a/core/contractsapi/stream_procedures.go
+++ b/core/contractsapi/stream_procedures.go
@@ -95,7 +95,21 @@ type InsertMetadataInput struct {
 	Value  types.MetadataValue
 }
 
+// ErrReservedMetadataKey is returned when a caller tries to route a
+// reserved metadata key (currently only AllowZerosKey) through the
+// generic insert/disable helpers. Reserved keys have dedicated mutators
+// (e.g. SetAllowZeros) that own the disable-then-insert sequence; the
+// generic path would let two parallel rows coexist and break the
+// "latest non-disabled wins" semantics that the node-side actions rely
+// on. The node enforces this too — this is a friendlier client-side
+// error for SDK developers.
+var ErrReservedMetadataKey = errors.New("reserved metadata key: use the dedicated mutator (e.g. SetAllowZeros)")
+
 func (s *Action) insertMetadata(ctx context.Context, input InsertMetadataInput) (kwiltypes.Hash, error) {
+	if input.Key == types.AllowZerosKey {
+		return kwiltypes.Hash{}, errors.Wrapf(ErrReservedMetadataKey, "%s", input.Key.String())
+	}
+
 	valType := input.Key.GetType()
 	valStr, err := valType.StringFromValue(input.Value)
 	if err != nil {

--- a/core/tnclient/actions_transport.go
+++ b/core/tnclient/actions_transport.go
@@ -162,6 +162,14 @@ func (a *TransportAction) SetDefaultBaseTime(ctx context.Context, input clientTy
 	return types.Hash{}, fmt.Errorf("SetDefaultBaseTime not implemented for custom transports - use HTTP transport or implement if needed")
 }
 
+func (a *TransportAction) SetAllowZeros(ctx context.Context, locator clientType.StreamLocator, value bool) (types.Hash, error) {
+	return types.Hash{}, fmt.Errorf("SetAllowZeros not implemented for custom transports - use HTTP transport or implement if needed")
+}
+
+func (a *TransportAction) GetAllowZeros(ctx context.Context, locator clientType.StreamLocator) (bool, error) {
+	return false, fmt.Errorf("GetAllowZeros not implemented for custom transports - use HTTP transport or implement if needed")
+}
+
 func (a *TransportAction) BatchStreamExists(ctx context.Context, streams []clientType.StreamLocator) ([]clientType.StreamExistsResult, error) {
 	return nil, fmt.Errorf("BatchStreamExists not implemented for custom transports - use HTTP transport or implement if needed")
 }

--- a/core/tnclient/client.go
+++ b/core/tnclient/client.go
@@ -219,7 +219,23 @@ func (c *Client) GetKwilClient() *gatewayclient.GatewayClient {
 	return nil
 }
 
+// DeployStreamOptions configures stream deployment behavior.
+// Zero-valued fields reproduce the historical defaults exactly, so
+// existing callers can continue to use DeployStream without change.
+type DeployStreamOptions struct {
+	// AllowZeros toggles persistence of value=0 inserts on the new stream.
+	// Default false: zeros are dropped on insert, today's behavior.
+	AllowZeros bool
+}
+
 func (c *Client) DeployStream(ctx context.Context, streamId util.StreamId, streamType clientType.StreamType) (types.Hash, error) {
+	return c.DeployStreamWithOptions(ctx, streamId, streamType, DeployStreamOptions{})
+}
+
+// DeployStreamWithOptions deploys a stream and applies the supplied
+// DeployStreamOptions. Use this instead of DeployStream when you need
+// non-default behavior (e.g. AllowZeros=true).
+func (c *Client) DeployStreamWithOptions(ctx context.Context, streamId util.StreamId, streamType clientType.StreamType, opts DeployStreamOptions) (types.Hash, error) {
 	// For HTTP transport, use the existing implementation (backwards compatible)
 	// For custom transports (CRE, etc.), use transport.Execute directly
 	if httpTransport, ok := c.transport.(*HTTPTransport); ok {
@@ -227,12 +243,14 @@ func (c *Client) DeployStream(ctx context.Context, streamId util.StreamId, strea
 			StreamId:   streamId,
 			StreamType: streamType,
 			KwilClient: httpTransport.gatewayClient,
+			AllowZeros: opts.AllowZeros,
 		})
 	}
 	// Use transport.Execute directly for custom transports
 	return c.transport.Execute(ctx, "", "create_stream", [][]any{{
 		streamId.String(),
 		streamType.String(),
+		opts.AllowZeros,
 	}})
 }
 

--- a/core/types/allow_zeros_test.go
+++ b/core/types/allow_zeros_test.go
@@ -1,0 +1,38 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trufnetwork/sdk-go/core/util"
+)
+
+// TestAllowZerosKeyType asserts the new metadata key maps to bool —
+// failing here surfaces a wiring mismatch that would otherwise only show
+// up at runtime when set_allow_zeros is invoked through insert_metadata.
+func TestAllowZerosKeyType(t *testing.T) {
+	require.Equal(t, MetadataTypeBool, AllowZerosKey.GetType())
+	require.Equal(t, "allow_zeros", AllowZerosKey.String())
+}
+
+// TestStreamDefinitionAllowZerosDefault locks in the additive-field
+// guarantee: a StreamDefinition built without setting AllowZeros must
+// default to false, which is what BatchDeployStreams relies on to keep
+// today's behavior for existing callers.
+func TestStreamDefinitionAllowZerosDefault(t *testing.T) {
+	id, err := util.NewStreamId("st00000000000000000000000000aabb")
+	require.NoError(t, err)
+
+	def := StreamDefinition{
+		StreamId:   *id,
+		StreamType: StreamTypePrimitive,
+	}
+	require.False(t, def.AllowZeros, "zero-value StreamDefinition must have AllowZeros=false")
+
+	defOptIn := StreamDefinition{
+		StreamId:   *id,
+		StreamType: StreamTypePrimitive,
+		AllowZeros: true,
+	}
+	require.True(t, defOptIn.AllowZeros)
+}

--- a/core/types/contract_values.go
+++ b/core/types/contract_values.go
@@ -27,6 +27,7 @@ const (
 	AllowReadWalletKey    MetadataKey = "allow_read_wallet"
 	AllowComposeStreamKey MetadataKey = "allow_compose_stream"
 	DefaultBaseTimeKey    MetadataKey = "default_base_time"
+	AllowZerosKey         MetadataKey = "allow_zeros"
 )
 
 func (s MetadataKey) GetType() MetadataType {
@@ -47,6 +48,8 @@ func (s MetadataKey) GetType() MetadataType {
 		return MetadataTypeRef
 	case DefaultBaseTimeKey:
 		return MetadataTypeInt
+	case AllowZerosKey:
+		return MetadataTypeBool
 	default:
 		return MetadataTypeString
 	}

--- a/core/types/stream.go
+++ b/core/types/stream.go
@@ -115,6 +115,17 @@ type IAction interface {
 	// SetDefaultBaseTime insert a metadata row with `default_base_time` key
 	SetDefaultBaseTime(ctx context.Context, input DefaultBaseTimeInput) (types.Hash, error)
 
+	// SetAllowZeros toggles whether value=0 inserts are persisted on the
+	// stream. Default behavior is FALSE (zeros are dropped on insert).
+	// Owner-gated. The toggle is forward-only — historical state is not
+	// rewritten by flipping the flag.
+	SetAllowZeros(ctx context.Context, locator StreamLocator, value bool) (types.Hash, error)
+
+	// GetAllowZeros returns the current allow_zeros setting for the stream.
+	// Returns false if the stream has no explicit metadata row (the
+	// implicit default).
+	GetAllowZeros(ctx context.Context, locator StreamLocator) (bool, error)
+
 	// GetStreamOwner gets the owner of the stream
 	GetStreamOwner(ctx context.Context, locator StreamLocator) ([]byte, error)
 

--- a/core/types/stream_types.go
+++ b/core/types/stream_types.go
@@ -29,4 +29,9 @@ type ListStreamsOutput struct {
 type StreamDefinition struct {
 	StreamId   util.StreamId // User-defined identifier for the stream
 	StreamType StreamType    // Type of the stream (Primitive, Composed, etc.)
+	// AllowZeros toggles persistence of value=0 inserts on this stream.
+	// Default false (zero value) preserves the historical behavior:
+	// zeros are silently dropped on insert. Set true for streams where
+	// zero is a meaningful measurement.
+	AllowZeros bool
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -444,6 +444,42 @@ txHash, err := tnClient.DeployStream(
 )
 ```
 
+##### `DeployStreamWithOptions`
+
+Deploy a new stream and apply per-stream options. Use this instead of
+`DeployStream` when you need non-default behavior — currently the
+`AllowZeros` toggle for streams where `value=0` is a meaningful measurement.
+
+```go
+txHash, err := tnClient.DeployStreamWithOptions(
+	ctx,
+	streamId,
+	types.StreamTypePrimitive,
+	tnclient.DeployStreamOptions{AllowZeros: true},
+)
+```
+
+`AllowZeros` defaults to `false` — zeros are dropped at insert time and
+excluded from `get_record` results, matching the historical behavior. The
+toggle can be flipped post-deployment via `IAction.SetAllowZeros`.
+
+##### `IAction.SetAllowZeros` / `IAction.GetAllowZeros`
+
+Owner-gated mutator and public reader for the per-stream `allow_zeros`
+flag. The flip is forward-only — historical inserts are not rewritten.
+
+```go
+action, _ := tnClient.LoadActions()
+_, _ = action.SetAllowZeros(ctx, tnClient.OwnStreamLocator(streamId), true)
+
+current, _ := action.GetAllowZeros(ctx, tnClient.OwnStreamLocator(streamId))
+// current == true
+```
+
+`StreamDefinition` (used with `BatchDeployStreams`) also exposes
+`AllowZeros` per definition; the zero-value field defaults to `false` so
+pre-existing batch callers continue to deploy zero-filtered streams.
+
 ##### `DestroyStream`
 
 Remove an existing stream:


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-stream `allow_zeros` setting to control zero-value persistence during inserts.
  * New `SetAllowZeros` and `GetAllowZeros` actions to manage the setting after stream creation.
  * Updated stream deployment with `DeployStreamWithOptions` to configure `allow_zeros` at creation.

* **Documentation**
  * Added API reference for new stream options and zero-handling behavior.

* **Tests**
  * Added test coverage for reserved metadata key protection and new allow_zeros functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->