### PR TITLE
chore: send agent-wallet rule flat fees as on-chain decimals

### DIFF
--- a/core/contractsapi/maa_actions.go
+++ b/core/contractsapi/maa_actions.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cockroachdb/apd/v3"
 	"github.com/pkg/errors"
 	kwilclient "github.com/trufnetwork/kwil-db/core/client"
 	kwilClientType "github.com/trufnetwork/kwil-db/core/client/types"
@@ -37,8 +36,12 @@ func (s *Action) CreateAgentRule(ctx context.Context, input types.MAACreateRuleI
 	if feeFlat == "" {
 		feeFlat = "0"
 	}
-	if _, _, derr := apd.NewFromString(feeFlat); derr != nil {
-		return nil, "", errors.Wrapf(derr, "invalid fee_flat %q", feeFlat)
+	// maa_create_rule declares $fee_flat NUMERIC(78,0); the engine type-checks action arguments against
+	// the declared type and does not coerce text to NUMERIC, so the fee is submitted as a decimal of
+	// exactly that precision/scale.
+	feeFlatNumeric, err := kwilTypes.ParseDecimalExplicit(feeFlat, 78, 0)
+	if err != nil {
+		return nil, "", errors.Wrapf(err, "fee_flat %q as NUMERIC(78,0)", feeFlat)
 	}
 
 	// Derive the rule_id locally from the same inputs the chain hashes (caller = restricted agent).
@@ -57,7 +60,7 @@ func (s *Action) CreateAgentRule(ctx context.Context, input types.MAACreateRuleI
 	}
 
 	// Args must match maa_create_rule($salt, $fee_mode, $fee_bps, $fee_flat, $namespaces, $actions, $body_hashes).
-	args := []any{input.Salt, input.FeeMode, input.FeeBps, feeFlat, input.Namespaces, input.Actions, input.BodyHashes}
+	args := []any{input.Salt, input.FeeMode, input.FeeBps, feeFlatNumeric, input.Namespaces, input.Actions, input.BodyHashes}
 	hash, err := s.execute(ctx, "maa_create_rule", [][]any{args})
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4070

## What

`CreateAgentRule` submits `fee_flat` as a `NUMERIC(78,0)` decimal — the type the on-chain `maa_create_rule` action declares — so the rule's flat-fee argument encodes to the action's declared type. The engine type-checks action arguments and does not coerce text to NUMERIC, so the fee is built as a precision/scale-exact `*types.Decimal` before submission.

This also replaces the prior `apd.NewFromString` validation with `ParseDecimalExplicit`, a stricter parse that validates the value against the declared precision and scale.
