### PR TITLE
feat: derive market-implied point forecast from order book

### DIFF
--- a/core/contractsapi/market_buckets.go
+++ b/core/contractsapi/market_buckets.go
@@ -102,12 +102,16 @@ func BucketBoundsFromMarketData(market *MarketData) (lower, upper *float64, err 
 				market.Type, tolerance)
 		}
 		lowerBound, upperBound := target-tolerance, target+tolerance
-		// Both operands are finite, but the sum or difference can still overflow
-		// near the float limits.
-		if math.IsInf(lowerBound, 0) || math.IsInf(upperBound, 0) {
+		// A positive tolerance does not guarantee a non-empty bucket. Near the
+		// float limits the sum can overflow to Inf, and a tolerance small enough
+		// relative to the target is absorbed entirely, collapsing both edges
+		// onto the same value: 1e300 +/- 1e-300 is 1e300 twice.
+		if math.IsInf(lowerBound, 0) || math.IsInf(upperBound, 0) ||
+			lowerBound >= upperBound {
 			return nil, nil, fmt.Errorf(
-				"an %q market with target %v and tolerance %v overflows its bounds",
-				market.Type, target, tolerance)
+				"an %q market with target %v and tolerance %v does not describe "+
+					"a usable bucket: [%v, %v)",
+				market.Type, target, tolerance, lowerBound, upperBound)
 		}
 		return forecast.Ptr(lowerBound), forecast.Ptr(upperBound), nil
 	}

--- a/core/contractsapi/market_buckets.go
+++ b/core/contractsapi/market_buckets.go
@@ -2,6 +2,7 @@ package contractsapi
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/trufnetwork/sdk-go/core/forecast"
@@ -38,6 +39,14 @@ func BucketBoundsFromMarketData(market *MarketData) (lower, upper *float64, err 
 				"threshold %d of a %q market is not a number: %q",
 				index, market.Type, market.Thresholds[index])
 		}
+		// ParseFloat accepts "NaN", "Inf" and "+Inf" without complaint. Those
+		// would flow all the way into the forecast and surface as a NaN value
+		// rather than as this market being unreadable.
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return 0, fmt.Errorf(
+				"threshold %d of a %q market is not finite: %q",
+				index, market.Type, market.Thresholds[index])
+		}
 		return value, nil
 	}
 
@@ -65,6 +74,14 @@ func BucketBoundsFromMarketData(market *MarketData) (lower, upper *float64, err 
 		if tErr != nil {
 			return nil, nil, tErr
 		}
+		// Bounds are half-open [lower, upper), so lower == upper is an empty
+		// bucket and lower > upper is an inverted one. Neither can hold an
+		// outcome, and both would quietly distort the tiling.
+		if lowerBound >= upperBound {
+			return nil, nil, fmt.Errorf(
+				"a %q market needs lower < upper, got [%v, %v)",
+				market.Type, lowerBound, upperBound)
+		}
 		return forecast.Ptr(lowerBound), forecast.Ptr(upperBound), nil
 
 	case "equals":
@@ -79,7 +96,20 @@ func BucketBoundsFromMarketData(market *MarketData) (lower, upper *float64, err 
 		if tErr != nil {
 			return nil, nil, tErr
 		}
-		return forecast.Ptr(target - tolerance), forecast.Ptr(target + tolerance), nil
+		if tolerance <= 0 {
+			return nil, nil, fmt.Errorf(
+				"an %q market needs a positive tolerance, got %v",
+				market.Type, tolerance)
+		}
+		lowerBound, upperBound := target-tolerance, target+tolerance
+		// Both operands are finite, but the sum or difference can still overflow
+		// near the float limits.
+		if math.IsInf(lowerBound, 0) || math.IsInf(upperBound, 0) {
+			return nil, nil, fmt.Errorf(
+				"an %q market with target %v and tolerance %v overflows its bounds",
+				market.Type, target, tolerance)
+		}
+		return forecast.Ptr(lowerBound), forecast.Ptr(upperBound), nil
 	}
 
 	return nil, nil, fmt.Errorf("cannot derive bucket bounds from a %q market", market.Type)

--- a/core/contractsapi/market_buckets.go
+++ b/core/contractsapi/market_buckets.go
@@ -1,0 +1,86 @@
+package contractsapi
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/trufnetwork/sdk-go/core/forecast"
+)
+
+// BucketBoundsFromMarketData turns one bucket market's decoded data into its
+// half-open [lower, upper) bounds.
+//
+// A nil bound means open-ended, which is how the outer two buckets of a market
+// are always struck. Bounds are half-open upstream, so a value landing exactly
+// on a boundary resolves the upper bucket only.
+//
+// This is SDK-side glue, deliberately kept OUT of the forecast package: that
+// package is a translation of the upstream algorithm in
+// truflation/prediction-bots and must stay comparable against it (and against
+// the sdk-py mirror). Nothing here is part of the forecast maths.
+//
+// Returns an error if the market type cannot describe a bucket, or the
+// thresholds needed for that type are missing.
+func BucketBoundsFromMarketData(market *MarketData) (lower, upper *float64, err error) {
+	if market == nil {
+		return nil, nil, fmt.Errorf("market data is required to derive bucket bounds")
+	}
+
+	threshold := func(index int) (float64, error) {
+		if len(market.Thresholds) <= index {
+			return 0, fmt.Errorf(
+				"a %q market needs at least %d threshold(s), got %d",
+				market.Type, index+1, len(market.Thresholds))
+		}
+		value, parseErr := strconv.ParseFloat(market.Thresholds[index], 64)
+		if parseErr != nil {
+			return 0, fmt.Errorf(
+				"threshold %d of a %q market is not a number: %q",
+				index, market.Type, market.Thresholds[index])
+		}
+		return value, nil
+	}
+
+	switch market.Type {
+	case "below":
+		upperBound, tErr := threshold(0)
+		if tErr != nil {
+			return nil, nil, tErr
+		}
+		return nil, forecast.Ptr(upperBound), nil
+
+	case "above":
+		lowerBound, tErr := threshold(0)
+		if tErr != nil {
+			return nil, nil, tErr
+		}
+		return forecast.Ptr(lowerBound), nil, nil
+
+	case "between":
+		lowerBound, tErr := threshold(0)
+		if tErr != nil {
+			return nil, nil, tErr
+		}
+		upperBound, tErr := threshold(1)
+		if tErr != nil {
+			return nil, nil, tErr
+		}
+		return forecast.Ptr(lowerBound), forecast.Ptr(upperBound), nil
+
+	case "equals":
+		// Thresholds are (target, tolerance), NOT (lower, upper). Reading them
+		// positionally the way "between" is read would give an inverted bucket
+		// and be silently wrong rather than loud.
+		target, tErr := threshold(0)
+		if tErr != nil {
+			return nil, nil, tErr
+		}
+		tolerance, tErr := threshold(1)
+		if tErr != nil {
+			return nil, nil, tErr
+		}
+		return forecast.Ptr(target - tolerance), forecast.Ptr(target + tolerance), nil
+	}
+
+	return nil, nil, fmt.Errorf("cannot derive bucket bounds from a %q market", market.Type)
+}

--- a/core/contractsapi/market_buckets_test.go
+++ b/core/contractsapi/market_buckets_test.go
@@ -350,9 +350,9 @@ func TestMarketIdentity_BucketsOfOneMarketShareAnIdentity(t *testing.T) {
 	above := base
 	above.Type, above.Thresholds = "above", []string{"4.92"}
 
-	want := marketIdentity(&below, settleTime)
-	assert.Equal(t, want, marketIdentity(&between, settleTime))
-	assert.Equal(t, want, marketIdentity(&above, settleTime))
+	want := marketIdentity(&below, "eth_usdc", settleTime)
+	assert.Equal(t, want, marketIdentity(&between, "eth_usdc", settleTime))
+	assert.Equal(t, want, marketIdentity(&above, "eth_usdc", settleTime))
 }
 
 func TestMarketIdentity_DiffersOnEveryEventField(t *testing.T) {
@@ -362,30 +362,98 @@ func TestMarketIdentity_DiffersOnEveryEventField(t *testing.T) {
 	queryTime := int64(1756771200)
 	base := MarketData{DataProvider: "0xabc", StreamID: "stmsft", Type: "below",
 		Thresholds: []string{"4.04"}, Timestamp: &queryTime}
-	want := marketIdentity(&base, settleTime)
+	want := marketIdentity(&base, "eth_usdc", settleTime)
 
 	otherProvider := base
 	otherProvider.DataProvider = "0xdef"
-	assert.NotEqual(t, want, marketIdentity(&otherProvider, settleTime))
+	assert.NotEqual(t, want, marketIdentity(&otherProvider, "eth_usdc", settleTime))
 
 	otherStream := base
 	otherStream.StreamID = "stnvda"
-	assert.NotEqual(t, want, marketIdentity(&otherStream, settleTime))
+	assert.NotEqual(t, want, marketIdentity(&otherStream, "eth_usdc", settleTime))
 
-	assert.NotEqual(t, want, marketIdentity(&base, settleTime+1))
+	assert.NotEqual(t, want, marketIdentity(&base, "eth_usdc", settleTime+1))
 
 	// The case settle_time alone cannot see: same provider, same stream, same
 	// settlement, but observing the stream at a different point.
 	laterQuery := queryTime + 86400
 	otherQueryTime := base
 	otherQueryTime.Timestamp = &laterQuery
-	assert.NotEqual(t, want, marketIdentity(&otherQueryTime, settleTime))
+	assert.NotEqual(t, want, marketIdentity(&otherQueryTime, "eth_usdc", settleTime))
 
 	frozen := int64(12345)
 	otherFrozen := base
 	otherFrozen.FrozenAt = &frozen
-	assert.NotEqual(t, want, marketIdentity(&otherFrozen, settleTime),
+	assert.NotEqual(t, want, marketIdentity(&otherFrozen, "eth_usdc", settleTime),
 		"a pinned block height is a different query than 'latest'")
+
+	// The bridge is the one identity field that lives outside the query
+	// components, so an identical question can be collateralised two ways.
+	assert.NotEqual(t, want, marketIdentity(&base, "eth_truf", settleTime),
+		"the same question on a different bridge is a separate market")
+}
+
+func TestRequireQueryTime_UnreadableTimestampIsRejected(t *testing.T) {
+	// The identity renders a nil timestamp as "null", so two malformed markets
+	// would collide there and merge. Refusing them is the point.
+	err := requireQueryTime(101, &MarketData{Type: "below", Thresholds: []string{"4.04"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no readable query timestamp")
+
+	queryTime := int64(1700000000)
+	assert.NoError(t, requireQueryTime(101,
+		&MarketData{Type: "below", Thresholds: []string{"4.04"}, Timestamp: &queryTime}))
+
+	// frozen_at stays legitimately nil: NULL there means "latest".
+	assert.NoError(t, requireQueryTime(101, &MarketData{
+		Type: "below", Thresholds: []string{"4.04"},
+		Timestamp: &queryTime, FrozenAt: nil,
+	}))
+
+	// An unknown action has an unknown layout, so argument 2 need not be a
+	// timestamp; the bounds derivation rejects it with a better message.
+	assert.NoError(t, requireQueryTime(101, &MarketData{Type: "unknown"}))
+}
+
+func TestRequireQueryTime_TwoUnreadableMarketsWouldHaveCollided(t *testing.T) {
+	// Demonstrates what the guard prevents: without it these two distinct
+	// markets share an identity, because both timestamps render as "null".
+	a := MarketData{DataProvider: "0xabc", StreamID: "stmsft", Type: "below"}
+	b := MarketData{DataProvider: "0xabc", StreamID: "stmsft", Type: "below"}
+	assert.Equal(t, marketIdentity(&a, "eth_usdc", 1), marketIdentity(&b, "eth_usdc", 1),
+		"identity cannot tell them apart, which is why they must be refused")
+	require.Error(t, requireQueryTime(101, &a))
+}
+
+func TestBucketBounds_NonFiniteThresholdsAreRejected(t *testing.T) {
+	// ParseFloat accepts these without complaint; left alone they surface as a
+	// NaN forecast rather than as an unreadable market.
+	for _, threshold := range []string{"NaN", "Inf", "+Inf", "-Inf"} {
+		_, _, err := BucketBoundsFromMarketData(
+			&MarketData{Type: "below", Thresholds: []string{threshold}})
+		require.Error(t, err, "threshold %q", threshold)
+		assert.Contains(t, err.Error(), "not finite")
+	}
+}
+
+func TestBucketBounds_InvertedBetweenBucketIsRejected(t *testing.T) {
+	// Bounds are half-open [lower, upper): equal bounds are empty and inverted
+	// ones can never hold an outcome.
+	for _, thresholds := range [][]string{{"4.62", "4.33"}, {"4.33", "4.33"}} {
+		_, _, err := BucketBoundsFromMarketData(
+			&MarketData{Type: "between", Thresholds: thresholds})
+		require.Error(t, err, "thresholds %v", thresholds)
+		assert.Contains(t, err.Error(), "lower < upper")
+	}
+}
+
+func TestBucketBounds_NonPositiveEqualsToleranceIsRejected(t *testing.T) {
+	for _, tolerance := range []string{"0", "-0.10"} {
+		_, _, err := BucketBoundsFromMarketData(
+			&MarketData{Type: "equals", Thresholds: []string{"5.25", tolerance}})
+		require.Error(t, err, "tolerance %q", tolerance)
+		assert.Contains(t, err.Error(), "positive tolerance")
+	}
 }
 
 func TestDecodeMarketData_CarriesTheQueryTime(t *testing.T) {

--- a/core/contractsapi/market_buckets_test.go
+++ b/core/contractsapi/market_buckets_test.go
@@ -447,6 +447,44 @@ func TestBucketBounds_InvertedBetweenBucketIsRejected(t *testing.T) {
 	}
 }
 
+func TestBucketBounds_CollapsedOrOverflowingEqualsBoundsAreRejected(t *testing.T) {
+	// A positive tolerance is not enough. Absorbed by a large target it leaves
+	// both edges on the same value, and near the float limits the sum overflows.
+	require.Equal(t, 1e300-1e-300, 1e300+1e-300, "the collapse, demonstrated")
+	for _, thresholds := range [][]string{
+		{"1e300", "1e-300"},
+		{"1.7e308", "1.7e308"},
+	} {
+		_, _, err := BucketBoundsFromMarketData(
+			&MarketData{Type: "equals", Thresholds: thresholds})
+		require.Error(t, err, "thresholds %v", thresholds)
+		assert.Contains(t, err.Error(), "usable bucket")
+	}
+}
+
+func TestDecodeMarketData_TruncatedArgsLeaveTheTimestampUnread(t *testing.T) {
+	// A missing final INT8 would otherwise decode to nil, indistinguishable from
+	// the explicit ABI NULL every well-formed market carries to mean "latest" --
+	// so a malformed market would match a healthy one on that component of its
+	// identity. Dropping the timestamp routes it to requireQueryTime instead.
+	const dataProvider = "0x4710a8d8f0d845da110086812a32de6d90d7ff5c"
+	const streamID = "stmsft00000000000000000000000000"
+
+	truncated, err := EncodeActionArgs(
+		[]any{dataProvider, streamID, int64(1700000000), "4.04"})
+	require.NoError(t, err)
+	encoded, err := EncodeQueryComponents(
+		dataProvider, streamID, "price_below_threshold", truncated)
+	require.NoError(t, err)
+
+	market, err := DecodeMarketData(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, "below", market.Type)
+	assert.Len(t, market.Thresholds, 1)
+	assert.Nil(t, market.Timestamp)
+	require.Error(t, requireQueryTime(101, market))
+}
+
 func TestBucketBounds_NonPositiveEqualsToleranceIsRejected(t *testing.T) {
 	for _, tolerance := range []string{"0", "-0.10"} {
 		_, _, err := BucketBoundsFromMarketData(

--- a/core/contractsapi/market_buckets_test.go
+++ b/core/contractsapi/market_buckets_test.go
@@ -359,8 +359,9 @@ func TestMarketIdentity_DiffersOnEveryEventField(t *testing.T) {
 	// Each field that changes describes a different event, so mixing those
 	// buckets into one distribution would normalise unrelated probabilities.
 	const settleTime = int64(1756771200)
+	queryTime := int64(1756771200)
 	base := MarketData{DataProvider: "0xabc", StreamID: "stmsft", Type: "below",
-		Thresholds: []string{"4.04"}}
+		Thresholds: []string{"4.04"}, Timestamp: &queryTime}
 	want := marketIdentity(&base, settleTime)
 
 	otherProvider := base
@@ -372,6 +373,60 @@ func TestMarketIdentity_DiffersOnEveryEventField(t *testing.T) {
 	assert.NotEqual(t, want, marketIdentity(&otherStream, settleTime))
 
 	assert.NotEqual(t, want, marketIdentity(&base, settleTime+1))
+
+	// The case settle_time alone cannot see: same provider, same stream, same
+	// settlement, but observing the stream at a different point.
+	laterQuery := queryTime + 86400
+	otherQueryTime := base
+	otherQueryTime.Timestamp = &laterQuery
+	assert.NotEqual(t, want, marketIdentity(&otherQueryTime, settleTime))
+
+	frozen := int64(12345)
+	otherFrozen := base
+	otherFrozen.FrozenAt = &frozen
+	assert.NotEqual(t, want, marketIdentity(&otherFrozen, settleTime),
+		"a pinned block height is a different query than 'latest'")
+}
+
+func TestDecodeMarketData_CarriesTheQueryTime(t *testing.T) {
+	// Timestamp is argument 2 for every binary action; frozen_at is last, and
+	// NULL there means "latest" rather than a decode failure.
+	const dataProvider = "0x4710a8d8f0d845da110086812a32de6d90d7ff5c"
+	const streamID = "stmsft00000000000000000000000000"
+	const queryTime = int64(1700000000)
+
+	args, err := EncodeActionArgs([]any{dataProvider, streamID, queryTime, "4.04", nil})
+	require.NoError(t, err)
+	encoded, err := EncodeQueryComponents(dataProvider, streamID, "price_below_threshold", args)
+	require.NoError(t, err)
+
+	market, err := DecodeMarketData(encoded)
+	require.NoError(t, err)
+	require.NotNil(t, market.Timestamp)
+	assert.Equal(t, queryTime, *market.Timestamp)
+	assert.Nil(t, market.FrozenAt, "NULL frozen_at means latest")
+}
+
+func TestDecodeMarketData_CarriesTheQueryTimeForRangeMarkets(t *testing.T) {
+	// Range markets carry two thresholds, so frozen_at sits one index later.
+	const dataProvider = "0x4710a8d8f0d845da110086812a32de6d90d7ff5c"
+	const streamID = "stmsft00000000000000000000000000"
+	const queryTime = int64(1700000000)
+	const frozenAt = int64(987654)
+
+	args, err := EncodeActionArgs(
+		[]any{dataProvider, streamID, queryTime, "4.04", "4.33", frozenAt})
+	require.NoError(t, err)
+	encoded, err := EncodeQueryComponents(dataProvider, streamID, "value_in_range", args)
+	require.NoError(t, err)
+
+	market, err := DecodeMarketData(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, "between", market.Type)
+	require.NotNil(t, market.Timestamp)
+	assert.Equal(t, queryTime, *market.Timestamp)
+	require.NotNil(t, market.FrozenAt)
+	assert.Equal(t, frozenAt, *market.FrozenAt)
 }
 
 func TestGetMarketForecastInput_NonPositiveQueryIDIsRejected(t *testing.T) {

--- a/core/contractsapi/market_buckets_test.go
+++ b/core/contractsapi/market_buckets_test.go
@@ -316,6 +316,64 @@ func TestGetMarketForecastInput_SingleBucketIsRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "at least 2")
 }
 
+func TestGetMarketForecastInput_DuplicateQueryIDsAreRejected(t *testing.T) {
+	// A repeated bucket would have its probability counted twice, quietly
+	// reshaping the distribution rather than failing.
+	input := types.GetMarketForecastInput{QueryIDs: []int{101, 102, 103, 103}}
+	err := input.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+	assert.Contains(t, err.Error(), "103")
+}
+
+func TestGetMarketForecastInput_RepeatsAreReportedOnceAndSorted(t *testing.T) {
+	input := types.GetMarketForecastInput{QueryIDs: []int{105, 103, 105, 103, 105}}
+	err := input.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "[103 105]")
+}
+
+// ═══════════════════════════════════════════════════════════════
+// MARKET IDENTITY
+// ═══════════════════════════════════════════════════════════════
+
+func TestMarketIdentity_BucketsOfOneMarketShareAnIdentity(t *testing.T) {
+	// Buckets differ only in their strike, so every bucket of one market must
+	// produce the same identity.
+	const settleTime = int64(1756771200)
+	base := MarketData{DataProvider: "0xabc", StreamID: "stmsft"}
+
+	below := base
+	below.Type, below.Thresholds = "below", []string{"4.04"}
+	between := base
+	between.Type, between.Thresholds = "between", []string{"4.04", "4.33"}
+	above := base
+	above.Type, above.Thresholds = "above", []string{"4.92"}
+
+	want := marketIdentity(&below, settleTime)
+	assert.Equal(t, want, marketIdentity(&between, settleTime))
+	assert.Equal(t, want, marketIdentity(&above, settleTime))
+}
+
+func TestMarketIdentity_DiffersOnEveryEventField(t *testing.T) {
+	// Each field that changes describes a different event, so mixing those
+	// buckets into one distribution would normalise unrelated probabilities.
+	const settleTime = int64(1756771200)
+	base := MarketData{DataProvider: "0xabc", StreamID: "stmsft", Type: "below",
+		Thresholds: []string{"4.04"}}
+	want := marketIdentity(&base, settleTime)
+
+	otherProvider := base
+	otherProvider.DataProvider = "0xdef"
+	assert.NotEqual(t, want, marketIdentity(&otherProvider, settleTime))
+
+	otherStream := base
+	otherStream.StreamID = "stnvda"
+	assert.NotEqual(t, want, marketIdentity(&otherStream, settleTime))
+
+	assert.NotEqual(t, want, marketIdentity(&base, settleTime+1))
+}
+
 func TestGetMarketForecastInput_NonPositiveQueryIDIsRejected(t *testing.T) {
 	input := types.GetMarketForecastInput{QueryIDs: []int{101, 0}}
 	require.Error(t, input.Validate())

--- a/core/contractsapi/market_buckets_test.go
+++ b/core/contractsapi/market_buckets_test.go
@@ -1,0 +1,327 @@
+// Tests for the SDK-side glue around the forecast algorithm.
+//
+// The algorithm itself is covered by core/forecast. What is tested here is only
+// what the SDK adds: deriving bucket bounds from decoded market data, splitting
+// raw order book rows into ladders, and assembling a market's books into a
+// forecast.
+//
+// Ported from sdk-py's tests/test_market_buckets.py. The client method itself
+// needs a node, so it is split: everything below the network call is exercised
+// here, and GetMarketForecast's plumbing is covered by the live integration
+// suite.
+
+package contractsapi
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trufnetwork/sdk-go/core/forecast"
+	"github.com/trufnetwork/sdk-go/core/types"
+)
+
+// ═══════════════════════════════════════════════════════════════
+// BUCKET BOUNDS FROM DECODED MARKET DATA
+// ═══════════════════════════════════════════════════════════════
+
+func TestBucketBounds_BelowMarketIsTheOpenBottomBucket(t *testing.T) {
+	lower, upper, err := BucketBoundsFromMarketData(
+		&MarketData{Type: "below", Thresholds: []string{"4.04"}})
+	require.NoError(t, err)
+	assert.Nil(t, lower)
+	require.NotNil(t, upper)
+	assert.InDelta(t, 4.04, *upper, 1e-12)
+}
+
+func TestBucketBounds_AboveMarketIsTheOpenTopBucket(t *testing.T) {
+	lower, upper, err := BucketBoundsFromMarketData(
+		&MarketData{Type: "above", Thresholds: []string{"4.92"}})
+	require.NoError(t, err)
+	require.NotNil(t, lower)
+	assert.InDelta(t, 4.92, *lower, 1e-12)
+	assert.Nil(t, upper)
+}
+
+func TestBucketBounds_BetweenMarketIsAnInteriorBucket(t *testing.T) {
+	lower, upper, err := BucketBoundsFromMarketData(
+		&MarketData{Type: "between", Thresholds: []string{"4.33", "4.62"}})
+	require.NoError(t, err)
+	require.NotNil(t, lower)
+	require.NotNil(t, upper)
+	assert.InDelta(t, 4.33, *lower, 1e-12)
+	assert.InDelta(t, 4.62, *upper, 1e-12)
+}
+
+func TestBucketBounds_EqualsMarketIsTargetPlusMinusTolerance(t *testing.T) {
+	// Its thresholds are (target, tolerance), NOT (lower, upper). Reading them
+	// positionally the way "between" is read would yield the bucket
+	// (5.25, 0.10): inverted, and silently wrong rather than loud.
+	lower, upper, err := BucketBoundsFromMarketData(
+		&MarketData{Type: "equals", Thresholds: []string{"5.25", "0.10"}})
+	require.NoError(t, err)
+	require.NotNil(t, lower)
+	require.NotNil(t, upper)
+	assert.InDelta(t, 5.15, *lower, 1e-12)
+	assert.InDelta(t, 5.35, *upper, 1e-12)
+	assert.Less(t, *lower, *upper)
+}
+
+func TestBucketBounds_UnknownMarketTypeIsRejected(t *testing.T) {
+	_, _, err := BucketBoundsFromMarketData(&MarketData{Type: "unknown"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot derive bucket bounds")
+}
+
+func TestBucketBounds_MissingThresholdsAreRejected(t *testing.T) {
+	_, _, err := BucketBoundsFromMarketData(
+		&MarketData{Type: "between", Thresholds: []string{"4.33"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "threshold")
+}
+
+func TestBucketBounds_RoundTripsThroughRealQueryComponents(t *testing.T) {
+	// The bounds are derived from bytes on chain, so decode the real encoding
+	// rather than trusting a hand-built struct.
+	const dataProvider = "0x4710a8d8f0d845da110086812a32de6d90d7ff5c"
+	const streamID = "stmsft00000000000000000000000000"
+
+	args, err := EncodeActionArgs([]any{dataProvider, streamID, int64(1700000000), "4.04", nil})
+	require.NoError(t, err)
+	encoded, err := EncodeQueryComponents(dataProvider, streamID, "price_below_threshold", args)
+	require.NoError(t, err)
+
+	market, err := DecodeMarketData(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, "below", market.Type)
+
+	lower, upper, err := BucketBoundsFromMarketData(market)
+	require.NoError(t, err)
+	assert.Nil(t, lower)
+	require.NotNil(t, upper)
+	assert.InDelta(t, 4.04, *upper, 1e-12)
+}
+
+// ═══════════════════════════════════════════════════════════════
+// LADDER CONVERSION (THE SIGN CONVENTION)
+// ═══════════════════════════════════════════════════════════════
+
+func TestLaddersFromEntries_NegativePriceIsABidPositiveIsAnAsk(t *testing.T) {
+	// Get this backwards and every one-sided bucket in the forecast inverts.
+	bids, asks := laddersFromEntries([]types.OrderBookEntry{
+		{Price: -44, Amount: 1000},
+		{Price: 56, Amount: 500},
+		{Price: -43, Amount: 200},
+	})
+
+	require.Len(t, bids, 2)
+	require.Len(t, asks, 1)
+	assert.Equal(t, forecast.BookLevel{Price: 44, Size: 1000}, bids[0])
+	assert.Equal(t, forecast.BookLevel{Price: 43, Size: 200}, bids[1])
+	assert.Equal(t, forecast.BookLevel{Price: 56, Size: 500}, asks[0])
+}
+
+func TestLaddersFromEntries_HoldingsAreNotPartOfTheBook(t *testing.T) {
+	// Price 0 means shares owned with no resting order.
+	bids, asks := laddersFromEntries([]types.OrderBookEntry{
+		{Price: 0, Amount: 9999},
+	})
+	assert.Empty(t, bids)
+	assert.Empty(t, asks)
+}
+
+// ═══════════════════════════════════════════════════════════════
+// ASSEMBLY
+// ═══════════════════════════════════════════════════════════════
+
+// Big enough that even a 1c level clears DepthMinSideNotionalUSD, so the dust
+// floor never silently empties a side these tests meant to be quoted.
+const testSize = 1000
+
+// msftMarket is one bucket of the live mainnet MSFT book, as a separate market.
+type msftMarket struct {
+	queryID int
+	market  *MarketData
+	yesBid  *float64
+	yesAsk  *float64
+}
+
+var msftMarkets = []msftMarket{
+	{101, &MarketData{Type: "below", Thresholds: []string{"4.04"}}, forecast.Ptr(1.0), nil},
+	{102, &MarketData{Type: "between", Thresholds: []string{"4.04", "4.33"}}, forecast.Ptr(16.0), forecast.Ptr(28.0)},
+	{103, &MarketData{Type: "between", Thresholds: []string{"4.33", "4.62"}}, forecast.Ptr(44.0), forecast.Ptr(56.0)},
+	{104, &MarketData{Type: "between", Thresholds: []string{"4.62", "4.92"}}, forecast.Ptr(9.0), forecast.Ptr(21.0)},
+	{105, &MarketData{Type: "above", Thresholds: []string{"4.92"}}, forecast.Ptr(1.0), nil},
+}
+
+// booksFor builds the BucketDepth slice GetMarketForecast would have fetched for
+// the given query_ids, taking the same bounds path off each market's data.
+func booksFor(t *testing.T, queryIDs []int, noBooks map[int][]types.OrderBookEntry) []forecast.BucketDepth {
+	t.Helper()
+	var books []forecast.BucketDepth
+	for _, queryID := range queryIDs {
+		var found *msftMarket
+		for i := range msftMarkets {
+			if msftMarkets[i].queryID == queryID {
+				found = &msftMarkets[i]
+			}
+		}
+		require.NotNil(t, found, "unknown query_id %d", queryID)
+
+		lower, upper, err := BucketBoundsFromMarketData(found.market)
+		require.NoError(t, err)
+
+		var yesEntries []types.OrderBookEntry
+		if found.yesBid != nil {
+			yesEntries = append(yesEntries, types.OrderBookEntry{Price: int(-*found.yesBid), Amount: testSize})
+		}
+		if found.yesAsk != nil {
+			yesEntries = append(yesEntries, types.OrderBookEntry{Price: int(*found.yesAsk), Amount: testSize})
+		}
+		yesBids, yesAsks := laddersFromEntries(yesEntries)
+		noBids, noAsks := laddersFromEntries(noBooks[queryID])
+
+		id := queryID
+		books = append(books, forecast.BucketDepth{
+			Lower: lower, Upper: upper,
+			YesBids: yesBids, YesAsks: yesAsks,
+			NoBids: noBids, NoAsks: noAsks,
+			QueryID: &id,
+		})
+	}
+	return books
+}
+
+func allQueryIDs() []int {
+	ids := make([]int, len(msftMarkets))
+	for i, m := range msftMarkets {
+		ids[i] = m.queryID
+	}
+	return ids
+}
+
+func hasWarning(f *forecast.MarketForecast, substring string) bool {
+	for _, w := range f.Warnings {
+		if strings.Contains(w, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAssembly_MatchesADirectCall(t *testing.T) {
+	// Assembly must not change the answer: same books in, same number out.
+	books := booksFor(t, allQueryIDs(), nil)
+	assembled := forecastFromBooks(books)
+	require.NotNil(t, assembled)
+
+	direct := forecast.FromDepth(booksFor(t, allQueryIDs(), nil))
+	require.NotNil(t, direct)
+
+	assert.InDelta(t, direct.Value, assembled.Value, 1e-12)
+	assert.InDelta(t, *direct.P10, *assembled.P10, 1e-12)
+	assert.InDelta(t, *direct.P90, *assembled.P90, 1e-12)
+	for i := range direct.Buckets {
+		assert.InDelta(t, direct.Buckets[i].Probability, assembled.Buckets[i].Probability, 1e-12)
+	}
+}
+
+func TestAssembly_LandsInsideTheLeadingBucket(t *testing.T) {
+	// The live MSFT book: the tight 44-56 bucket leads, so the value belongs
+	// inside it.
+	f := forecastFromBooks(booksFor(t, allQueryIDs(), nil))
+	require.NotNil(t, f)
+
+	top := 0.0
+	for _, b := range f.Buckets {
+		top = math.Max(top, b.Probability)
+	}
+	assert.Equal(t, top, f.Buckets[2].Probability)
+	assert.GreaterOrEqual(t, f.Value, 4.33)
+	assert.LessOrEqual(t, f.Value, 4.62)
+}
+
+func TestAssembly_NoSideLiquidityIsConsolidatedIntoTheEstimate(t *testing.T) {
+	// A resting BUY NO at p is hittable by a BUY YES at 100-p, so NO depth is
+	// executable YES depth. Adding a NO bid must therefore supply the missing
+	// YES ask and stop the bucket reading as one-sided.
+	bare := forecastFromBooks(booksFor(t, allQueryIDs(), nil))
+	require.NotNil(t, bare)
+
+	// A NO bid at 84 mirrors to a YES ask at 16 on the open bottom bucket.
+	withNo := forecastFromBooks(booksFor(t, allQueryIDs(), map[int][]types.OrderBookEntry{
+		101: {{Price: -84, Amount: testSize}},
+	}))
+	require.NotNil(t, withNo)
+
+	assert.True(t, bare.Buckets[0].OneSided)
+	assert.False(t, withNo.Buckets[0].OneSided)
+	assert.Greater(t, withNo.Buckets[0].Confidence, bare.Buckets[0].Confidence)
+}
+
+func TestAssembly_QueryIDsMayBeGivenInAnyOrder(t *testing.T) {
+	// Buckets are sorted by bound here, so callers need not track which query_id
+	// is the bottom of the line.
+	ordered := forecastFromBooks(booksFor(t, []int{101, 102, 103, 104, 105}, nil))
+	shuffled := forecastFromBooks(booksFor(t, []int{103, 105, 101, 104, 102}, nil))
+	require.NotNil(t, ordered)
+	require.NotNil(t, shuffled)
+
+	assert.InDelta(t, ordered.Value, shuffled.Value, 1e-12)
+	got := make([]int, len(shuffled.Buckets))
+	for i, b := range shuffled.Buckets {
+		got[i] = *b.QueryID
+	}
+	assert.Equal(t, []int{101, 102, 103, 104, 105}, got)
+	assert.True(t, sort.IntsAreSorted(got))
+}
+
+func TestAssembly_GapInTheBucketLayoutIsReportedNotHidden(t *testing.T) {
+	// A market missing an interior bucket still gets an estimate, but the caller
+	// must be able to see that the line was not fully tiled.
+	f := forecastFromBooks(booksFor(t, []int{101, 102, 104, 105}, nil))
+	require.NotNil(t, f)
+	assert.True(t, hasWarning(f, "gap"))
+}
+
+func TestAssembly_LayoutWarningWhenTheLineIsNotOpenEnded(t *testing.T) {
+	// Interior buckets only: nothing covers the tails, so the mass beyond them
+	// is unrepresented and the caller should know.
+	f := forecastFromBooks(booksFor(t, []int{102, 103, 104}, nil))
+	require.NotNil(t, f)
+	assert.True(t, hasWarning(f, "not open below"))
+	assert.True(t, hasWarning(f, "not open above"))
+}
+
+func TestAssembly_UnquotedMarketYieldsNoForecast(t *testing.T) {
+	dead := booksFor(t, allQueryIDs(), nil)
+	for i := range dead {
+		dead[i].YesBids, dead[i].YesAsks = nil, nil
+		dead[i].NoBids, dead[i].NoAsks = nil, nil
+	}
+	assert.Nil(t, forecastFromBooks(dead))
+}
+
+// ═══════════════════════════════════════════════════════════════
+// INPUT VALIDATION
+// ═══════════════════════════════════════════════════════════════
+
+func TestGetMarketForecastInput_SingleBucketIsRejected(t *testing.T) {
+	input := types.GetMarketForecastInput{QueryIDs: []int{103}}
+	err := input.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 2")
+}
+
+func TestGetMarketForecastInput_NonPositiveQueryIDIsRejected(t *testing.T) {
+	input := types.GetMarketForecastInput{QueryIDs: []int{101, 0}}
+	require.Error(t, input.Validate())
+}
+
+func TestGetMarketForecastInput_ValidMarketIsAccepted(t *testing.T) {
+	input := types.GetMarketForecastInput{QueryIDs: allQueryIDs()}
+	assert.NoError(t, input.Validate())
+}

--- a/core/contractsapi/order_book_forecast.go
+++ b/core/contractsapi/order_book_forecast.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/trufnetwork/sdk-go/core/forecast"
@@ -58,17 +59,17 @@ func (o *OrderBook) GetMarketForecast(ctx context.Context, input types.GetMarket
 		}
 
 		// Buckets of one market differ only in their strike: they share a data
-		// provider, a stream and a settlement time. Forecasting across two
-		// events would normalise unrelated probabilities into one distribution
-		// and return a confident number about nothing, so it is rejected rather
-		// than warned about.
+		// provider, a stream, a settlement time and the query time they observe.
+		// Forecasting across two events would normalise unrelated probabilities
+		// into one distribution and return a confident number about nothing, so
+		// it is rejected rather than warned about.
 		thisIdentity := marketIdentity(market, info.SettleTime)
 		if i == 0 {
 			identity = thisIdentity
 		} else if thisIdentity != identity {
 			return nil, errors.Errorf(
 				"market %d belongs to a different event than the first bucket: "+
-					"(data_provider, stream_id, settle_time) is %s against %s. "+
+					"(data_provider, stream_id, settle_time, timestamp, frozen_at) is %s against %s. "+
 					"One forecast covers the buckets of ONE market.",
 				queryID, thisIdentity, identity)
 		}
@@ -153,9 +154,26 @@ func forecastFromBooks(books []forecast.BucketDepth) *forecast.MarketForecast {
 // market shares. Buckets differ only in their strike, so anything outside the
 // strike identifies the event itself.
 //
+// The query's own timestamp and frozen_at are included, not just the settlement
+// time: two markets can settle at the same moment while observing the stream at
+// different points, and merging those would be exactly the mistake this guards
+// against. On mainnet today the settle time and the query timestamp happen to
+// coincide, which is why this costs nothing in practice.
+//
 // Kept as a pure function so the comparison can be tested without a node.
 func marketIdentity(market *MarketData, settleTime int64) string {
-	return fmt.Sprintf("%s|%s|%d", market.DataProvider, market.StreamID, settleTime)
+	return fmt.Sprintf("%s|%s|%d|%s|%s",
+		market.DataProvider, market.StreamID, settleTime,
+		formatOptionalInt64(market.Timestamp), formatOptionalInt64(market.FrozenAt))
+}
+
+// formatOptionalInt64 renders a nullable INT8 for the identity string. "null"
+// is a distinct value: frozen_at uses it to mean "latest".
+func formatOptionalInt64(v *int64) string {
+	if v == nil {
+		return "null"
+	}
+	return strconv.FormatInt(*v, 10)
 }
 
 // sameBound reports whether two optional bounds describe the same edge. Two

--- a/core/contractsapi/order_book_forecast.go
+++ b/core/contractsapi/order_book_forecast.go
@@ -1,0 +1,183 @@
+package contractsapi
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/trufnetwork/sdk-go/core/forecast"
+	"github.com/trufnetwork/sdk-go/core/types"
+)
+
+// ═══════════════════════════════════════════════════════════════
+// MARKET FORECASTING
+// ═══════════════════════════════════════════════════════════════
+
+// GetMarketForecast collapses a market's bucket books into the single value they
+// imply.
+//
+// A prediction market prices ranges: each bucket is its own query_id with its
+// own binary book. This reads every bucket's FULL YES and NO ladders and its
+// bounds, then returns the one number the books collectively imply plus the band
+// around it. See the forecast package for the algorithm.
+//
+// The YES and NO books are both fetched because the forecast consolidates them:
+// on this venue a resting BUY NO at p is hittable by a BUY YES at 100-p (mint
+// match), so NO liquidity is executable YES liquidity and ignoring it would
+// discard real quotes. That costs two order-book reads per bucket.
+//
+// The buckets are expected to tile the whole line, with the bottom one open
+// below and the top one open above; a layout that does not is still estimated,
+// with the problem reported in the forecast's Warnings rather than returned as
+// an error.
+//
+// Returns a nil forecast, and no error, when no bucket has a usable quote.
+func (o *OrderBook) GetMarketForecast(ctx context.Context, input types.GetMarketForecastInput) (
+	*forecast.MarketForecast, error,
+) {
+	if err := input.Validate(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	books := make([]forecast.BucketDepth, 0, len(input.QueryIDs))
+	for _, queryID := range input.QueryIDs {
+		info, err := o.GetMarketInfo(ctx, types.GetMarketInfoInput{QueryID: queryID})
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		if len(info.QueryComponents) == 0 {
+			return nil, errors.Errorf(
+				"market %d has no query_components, so its bucket bounds cannot be derived",
+				queryID)
+		}
+		market, err := DecodeMarketData(info.QueryComponents)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to decode market %d", queryID)
+		}
+		lower, upper, err := BucketBoundsFromMarketData(market)
+		if err != nil {
+			return nil, errors.Wrapf(err, "market %d", queryID)
+		}
+
+		yesBids, yesAsks, err := o.orderBookLadders(ctx, queryID, true)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		noBids, noAsks, err := o.orderBookLadders(ctx, queryID, false)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		id := queryID
+		books = append(books, forecast.BucketDepth{
+			Lower:   lower,
+			Upper:   upper,
+			YesBids: yesBids,
+			YesAsks: yesAsks,
+			NoBids:  noBids,
+			NoAsks:  noAsks,
+			QueryID: &id,
+		})
+	}
+
+	return forecastFromBooks(books), nil
+}
+
+// forecastFromBooks orders a market's bucket books and forecasts from them,
+// prepending any problem with the bucket layout to the warnings.
+//
+// Split out from GetMarketForecast so the ordering and layout checks can be
+// tested without a node: everything above this point is network I/O, everything
+// below is a pure function of the books.
+func forecastFromBooks(books []forecast.BucketDepth) *forecast.MarketForecast {
+	if len(books) == 0 {
+		return nil
+	}
+
+	// Open below sorts first, which is where that bucket belongs.
+	sort.SliceStable(books, func(i, j int) bool {
+		if books[i].Lower == nil {
+			return books[j].Lower != nil
+		}
+		if books[j].Lower == nil {
+			return false
+		}
+		return *books[i].Lower < *books[j].Lower
+	})
+
+	var layout []string
+	if books[0].Lower != nil {
+		layout = append(layout, "lowest bucket is not open below")
+	}
+	if books[len(books)-1].Upper != nil {
+		layout = append(layout, "highest bucket is not open above")
+	}
+	breaks := 0
+	for i := 0; i+1 < len(books); i++ {
+		if !sameBound(books[i].Upper, books[i+1].Lower) {
+			breaks++
+		}
+	}
+	if breaks > 0 {
+		layout = append(layout, fmt.Sprintf("%d gap(s) or overlap(s) between bucket bounds", breaks))
+	}
+
+	result := forecast.FromDepth(books)
+	if result == nil {
+		return nil
+	}
+	result.Warnings = append(layout, result.Warnings...)
+	return result
+}
+
+// sameBound reports whether two optional bounds describe the same edge. Two
+// open ends match; an open end never matches a number.
+func sameBound(a, b *float64) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+// orderBookLadders returns one outcome's resting book, split into bid and ask
+// ladders.
+//
+// GetOrderBook marks bids with a NEGATIVE price and asks with a positive one;
+// price 0 means shares held with no resting order, which is not part of the
+// book. Prices come back to the forecast as the positive 1-99 cent convention it
+// expects.
+func (o *OrderBook) orderBookLadders(ctx context.Context, queryID int, outcome bool) (
+	bids, asks []forecast.BookLevel, err error,
+) {
+	entries, err := o.GetOrderBook(ctx, types.GetOrderBookInput{QueryID: queryID, Outcome: outcome})
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	bids, asks = laddersFromEntries(entries)
+	return bids, asks, nil
+}
+
+// laddersFromEntries splits raw order book rows into bid and ask ladders.
+//
+// The sign convention is the whole point: a NEGATIVE price is a bid, a positive
+// one is an ask, and 0 is a holding rather than a resting order. Get this
+// backwards and every one-sided bucket in the forecast inverts silently, so it
+// is kept as a pure function that can be tested without a node.
+func laddersFromEntries(entries []types.OrderBookEntry) (bids, asks []forecast.BookLevel) {
+	for _, entry := range entries {
+		switch {
+		case entry.Price < 0:
+			bids = append(bids, forecast.BookLevel{
+				Price: float64(-entry.Price),
+				Size:  float64(entry.Amount),
+			})
+		case entry.Price > 0:
+			asks = append(asks, forecast.BookLevel{
+				Price: float64(entry.Price),
+				Size:  float64(entry.Amount),
+			})
+		}
+	}
+	return bids, asks
+}

--- a/core/contractsapi/order_book_forecast.go
+++ b/core/contractsapi/order_book_forecast.go
@@ -41,7 +41,8 @@ func (o *OrderBook) GetMarketForecast(ctx context.Context, input types.GetMarket
 	}
 
 	books := make([]forecast.BucketDepth, 0, len(input.QueryIDs))
-	for _, queryID := range input.QueryIDs {
+	identity := ""
+	for i, queryID := range input.QueryIDs {
 		info, err := o.GetMarketInfo(ctx, types.GetMarketInfoInput{QueryID: queryID})
 		if err != nil {
 			return nil, errors.WithStack(err)
@@ -55,6 +56,23 @@ func (o *OrderBook) GetMarketForecast(ctx context.Context, input types.GetMarket
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to decode market %d", queryID)
 		}
+
+		// Buckets of one market differ only in their strike: they share a data
+		// provider, a stream and a settlement time. Forecasting across two
+		// events would normalise unrelated probabilities into one distribution
+		// and return a confident number about nothing, so it is rejected rather
+		// than warned about.
+		thisIdentity := marketIdentity(market, info.SettleTime)
+		if i == 0 {
+			identity = thisIdentity
+		} else if thisIdentity != identity {
+			return nil, errors.Errorf(
+				"market %d belongs to a different event than the first bucket: "+
+					"(data_provider, stream_id, settle_time) is %s against %s. "+
+					"One forecast covers the buckets of ONE market.",
+				queryID, thisIdentity, identity)
+		}
+
 		lower, upper, err := BucketBoundsFromMarketData(market)
 		if err != nil {
 			return nil, errors.Wrapf(err, "market %d", queryID)
@@ -129,6 +147,15 @@ func forecastFromBooks(books []forecast.BucketDepth) *forecast.MarketForecast {
 	}
 	result.Warnings = append(layout, result.Warnings...)
 	return result
+}
+
+// marketIdentity is the part of a market's definition that every bucket of one
+// market shares. Buckets differ only in their strike, so anything outside the
+// strike identifies the event itself.
+//
+// Kept as a pure function so the comparison can be tested without a node.
+func marketIdentity(market *MarketData, settleTime int64) string {
+	return fmt.Sprintf("%s|%s|%d", market.DataProvider, market.StreamID, settleTime)
 }
 
 // sameBound reports whether two optional bounds describe the same edge. Two

--- a/core/contractsapi/order_book_forecast.go
+++ b/core/contractsapi/order_book_forecast.go
@@ -58,18 +58,22 @@ func (o *OrderBook) GetMarketForecast(ctx context.Context, input types.GetMarket
 			return nil, errors.Wrapf(err, "failed to decode market %d", queryID)
 		}
 
+		if err := requireQueryTime(queryID, market); err != nil {
+			return nil, errors.WithStack(err)
+		}
+
 		// Buckets of one market differ only in their strike: they share a data
-		// provider, a stream, a settlement time and the query time they observe.
-		// Forecasting across two events would normalise unrelated probabilities
-		// into one distribution and return a confident number about nothing, so
-		// it is rejected rather than warned about.
-		thisIdentity := marketIdentity(market, info.SettleTime)
+		// provider, a stream, a bridge, a settlement time and the query time
+		// they observe. Forecasting across two events would normalise unrelated
+		// probabilities into one distribution and return a confident number
+		// about nothing, so it is rejected rather than warned about.
+		thisIdentity := marketIdentity(market, info.Bridge, info.SettleTime)
 		if i == 0 {
 			identity = thisIdentity
 		} else if thisIdentity != identity {
 			return nil, errors.Errorf(
 				"market %d belongs to a different event than the first bucket: "+
-					"(data_provider, stream_id, settle_time, timestamp, frozen_at) is %s against %s. "+
+					"(data_provider, stream_id, bridge, settle_time, timestamp, frozen_at) is %s against %s. "+
 					"One forecast covers the buckets of ONE market.",
 				queryID, thisIdentity, identity)
 		}
@@ -160,11 +164,36 @@ func forecastFromBooks(books []forecast.BucketDepth) *forecast.MarketForecast {
 // against. On mainnet today the settle time and the query timestamp happen to
 // coincide, which is why this costs nothing in practice.
 //
+// The bridge is in here too, and it is the one field that lives outside the
+// query components: it is a create_market argument, so two markets can ask an
+// identical question while collateralising it differently. Those are separate
+// markets with separate books, and averaging them would be meaningless.
+//
 // Kept as a pure function so the comparison can be tested without a node.
-func marketIdentity(market *MarketData, settleTime int64) string {
-	return fmt.Sprintf("%s|%s|%d|%s|%s",
-		market.DataProvider, market.StreamID, settleTime,
+func marketIdentity(market *MarketData, bridge string, settleTime int64) string {
+	return fmt.Sprintf("%s|%s|%s|%d|%s|%s",
+		market.DataProvider, market.StreamID, bridge, settleTime,
 		formatOptionalInt64(market.Timestamp), formatOptionalInt64(market.FrozenAt))
+}
+
+// requireQueryTime rejects a market whose query timestamp could not be read.
+//
+// Every binary action carries one at argument 2; only frozen_at is nullable. A
+// nil timestamp renders as "null" in the identity, so two malformed markets
+// would COLLIDE on that component and merge silently -- the identity check
+// failing open in exactly the case it exists to catch. Better to refuse a market
+// we cannot pin down than to match it by accident.
+//
+// Unknown action types are left alone: their layout is unknown, so argument 2
+// need not be a timestamp at all, and BucketBoundsFromMarketData already turns
+// them away with a clearer message.
+func requireQueryTime(queryID int, market *MarketData) error {
+	if market.Type != "unknown" && market.Timestamp == nil {
+		return errors.Errorf(
+			"market %d carries no readable query timestamp, so it cannot be "+
+				"matched against the other buckets of its market", queryID)
+	}
+	return nil
 }
 
 // formatOptionalInt64 renders a nullable INT8 for the identity string. "null"

--- a/core/contractsapi/query_components.go
+++ b/core/contractsapi/query_components.go
@@ -157,6 +157,23 @@ type MarketData struct {
 	FrozenAt *int64 `json:"frozen_at"`
 }
 
+// readQueryTime fills in a market's query time, but only when the whole
+// argument list is present.
+//
+// Both slots have to exist for either to mean anything. A truncated argument
+// list would otherwise leave FrozenAt nil, which is indistinguishable from the
+// explicit ABI NULL that every well-formed market carries to mean "latest" --
+// so a malformed market would match a healthy one on that component of its
+// identity. Leaving Timestamp nil instead hands the whole market to the
+// caller's readability check.
+func readQueryTime(market *MarketData, args []any, frozenAtIndex int) {
+	if len(args) <= frozenAtIndex {
+		return
+	}
+	market.Timestamp = argInt64(args, 2)
+	market.FrozenAt = argInt64(args, frozenAtIndex)
+}
+
 // argInt64 pulls an INT8 argument out of the decoded args.
 //
 // Kwil hands these back as *int64, and a nil argument is meaningful rather than
@@ -205,7 +222,7 @@ func DecodeMarketData(encoded []byte) (*MarketData, error) {
 		if arg == nil {
 			return ""
 		}
-		
+
 		// Handle *string directly (common in decoded results)
 		if s, ok := arg.(*string); ok {
 			if s == nil {
@@ -239,29 +256,25 @@ func DecodeMarketData(encoded []byte) (*MarketData, error) {
 		if len(args) >= 4 {
 			market.Thresholds = append(market.Thresholds, formatArg(args[3]))
 		}
-		market.Timestamp = argInt64(args, 2)
-		market.FrozenAt = argInt64(args, 4)
+		readQueryTime(market, args, 4)
 	case "price_below_threshold":
 		market.Type = "below"
 		if len(args) >= 4 {
 			market.Thresholds = append(market.Thresholds, formatArg(args[3]))
 		}
-		market.Timestamp = argInt64(args, 2)
-		market.FrozenAt = argInt64(args, 4)
+		readQueryTime(market, args, 4)
 	case "value_in_range":
 		market.Type = "between"
 		if len(args) >= 5 {
 			market.Thresholds = append(market.Thresholds, formatArg(args[3]), formatArg(args[4]))
 		}
-		market.Timestamp = argInt64(args, 2)
-		market.FrozenAt = argInt64(args, 5)
+		readQueryTime(market, args, 5)
 	case "value_equals":
 		market.Type = "equals"
 		if len(args) >= 5 {
 			market.Thresholds = append(market.Thresholds, formatArg(args[3]), formatArg(args[4]))
 		}
-		market.Timestamp = argInt64(args, 2)
-		market.FrozenAt = argInt64(args, 5)
+		readQueryTime(market, args, 5)
 	default:
 		market.Type = "unknown"
 	}

--- a/core/contractsapi/query_components.go
+++ b/core/contractsapi/query_components.go
@@ -148,6 +148,37 @@ type MarketData struct {
 	ActionID     string   `json:"action_id"`
 	Type         string   `json:"type"`       // "above", "below", "between", "equals"
 	Thresholds   []string `json:"thresholds"` // Formatted numeric values
+	// Timestamp is the point in the stream the query observes, in unix seconds.
+	// Every bucket of one market shares it; nil only when the arguments could
+	// not be read.
+	Timestamp *int64 `json:"timestamp"`
+	// FrozenAt is the block height the data is pinned to. It is encoded as NULL
+	// to mean "latest", so nil is a real value rather than a decode failure.
+	FrozenAt *int64 `json:"frozen_at"`
+}
+
+// argInt64 pulls an INT8 argument out of the decoded args.
+//
+// Kwil hands these back as *int64, and a nil argument is meaningful rather than
+// an error: frozen_at is encoded as NULL to mean "latest".
+func argInt64(args []any, index int) *int64 {
+	if index < 0 || index >= len(args) || args[index] == nil {
+		return nil
+	}
+	switch v := args[index].(type) {
+	case *int64:
+		if v == nil {
+			return nil
+		}
+		n := *v
+		return &n
+	case int64:
+		return &v
+	case int:
+		n := int64(v)
+		return &n
+	}
+	return nil
 }
 
 // DecodeMarketData decodes ABI-encoded query_components into high-level MarketData
@@ -198,27 +229,39 @@ func DecodeMarketData(encoded []byte) (*MarketData, error) {
 
 	// Map action_id to market type and thresholds
 	// Based on 040-binary-attestation-actions.sql
+	//
+	// Every binary action takes ($data_provider, $stream_id, $timestamp, ...,
+	// $frozen_at), so the timestamp is always argument 2 and frozen_at is always
+	// last. Only the thresholds in between change shape.
 	switch actionID {
 	case "price_above_threshold":
 		market.Type = "above"
 		if len(args) >= 4 {
 			market.Thresholds = append(market.Thresholds, formatArg(args[3]))
 		}
+		market.Timestamp = argInt64(args, 2)
+		market.FrozenAt = argInt64(args, 4)
 	case "price_below_threshold":
 		market.Type = "below"
 		if len(args) >= 4 {
 			market.Thresholds = append(market.Thresholds, formatArg(args[3]))
 		}
+		market.Timestamp = argInt64(args, 2)
+		market.FrozenAt = argInt64(args, 4)
 	case "value_in_range":
 		market.Type = "between"
 		if len(args) >= 5 {
 			market.Thresholds = append(market.Thresholds, formatArg(args[3]), formatArg(args[4]))
 		}
+		market.Timestamp = argInt64(args, 2)
+		market.FrozenAt = argInt64(args, 5)
 	case "value_equals":
 		market.Type = "equals"
 		if len(args) >= 5 {
 			market.Thresholds = append(market.Thresholds, formatArg(args[3]), formatArg(args[4]))
 		}
+		market.Timestamp = argInt64(args, 2)
+		market.FrozenAt = argInt64(args, 5)
 	default:
 		market.Type = "unknown"
 	}

--- a/core/forecast/forecast.go
+++ b/core/forecast/forecast.go
@@ -1,0 +1,1215 @@
+// Package forecast turns prediction-market order book state into a single
+// implied value.
+//
+// Prediction markets price RANGES. A five-bucket EPS market says "38% chance EPS
+// lands between $4.33 and $4.62"; it never says "EPS will be $4.47". This
+// package inverts that. Given the order books across every bucket of one market,
+// it produces the single number the book is collectively implying, together with
+// how tightly the book pins that number down.
+//
+//	market says            ->   this package says
+//	"34% between 2.40-2.63"     "2.43, margin of error 0.02"
+//
+// # How it works
+//
+// A market is N buckets, each its own query_id and its own binary book, and the
+// outer two are open-ended:
+//
+//	bucket 1  (-inf, B1)      bucket 2  [B1, B2)   ...   bucket N  [Bn-1, +inf)
+//
+// Bounds are HALF-OPEN, matching how the markets are actually created
+// (value < upper; value >= lower AND value < upper; value >= lower). So the
+// buckets are mutually exclusive and exhaustive, and a value landing exactly on
+// a boundary resolves the UPPER bucket only.
+//
+// Each bucket's book implies a probability. Two-sided is the mid, with
+// confidence from how tight the spread is. One-sided takes the quoted side and
+// steps across by the market's own median half-spread, at reduced confidence: on
+// real books the open tail buckets are often bid-only at a penny, and treating
+// that as the midpoint of [0.01, 1.0] calls a dead tail a coin flip. That single
+// mistake handed MSFT's two tails 27% each and buried the real distribution, so
+// the rule matters more than it looks.
+//
+// Bucket probabilities are normalised to sum to 1, since independent books never
+// sum to exactly 1 on their own because of spreads and staleness. A bucket with
+// no orders at all takes the residual the quoted buckets leave behind rather
+// than an invented value. Those give the implied CDF at each interior boundary.
+//
+// The point estimate is the MEDIAN read directly off that CDF (rank method):
+// walk up the cumulative probabilities until they cross 50% and interpolate
+// within the bucket where the crossing happens. No distribution shape is assumed
+// for anything interior. The published band is P10..P90 read the same way. When
+// a requested percentile falls inside an OPEN-ENDED outer bucket the books
+// contain no information about how far out it lies, so an exponential tail
+// matched to the adjacent bucket's density supplies a number, and the result is
+// flagged (ValueBasis / P10Basis / P90Basis = "tail") so consumers can decide
+// whether to show it. Markets struck so that the mass stays between the outer
+// boundaries never need the tail model at all.
+//
+// Confidence per bucket is (1 - spread) * min(1, n / median(n)) with n the
+// thinner side's committed dollars, standardised against the market's own depth
+// so no external constant is needed. It does not move the median; it is
+// published as book quality and drives warnings.
+package forecast
+
+// Translated from truflation/prediction-bots @ main 21fe4f3 (PR #37), upstream
+// path market-maker-bot/src/market_maker_bot/forecast.py, by way of the
+// byte-identical mirror in trufnetwork/sdk-py (src/trufnetwork_sdk_py/forecast.py).
+//
+// sdk-py can keep a verbatim copy and re-sync with a diff. Go cannot, so this is
+// a hand translation and drift has to be caught by BEHAVIOUR instead:
+// forecast_test.go and forecast_depth_test.go are ports of the upstream suites,
+// including the frozen live NVDA book, and are the contract that keeps the SDKs
+// agreeing. Change the algorithm upstream first, then port it here and re-run
+// both suites.
+//
+// Verified against sdk-py over 39 shared cases (best-quote and depth paths,
+// tails, the discrete fallback, dutch books, dust griefing, the frozen NVDA
+// book) and against a live mainnet market.
+//
+// The residual is ~1e-16, worst case 6.5 ULP, from two causes, neither of them
+// fixable and neither of them a translation error:
+//
+//  1. CPython 3.12 gave sum() compensated (Neumaier) summation for floats, so
+//     the Python sums are slightly MORE accurate than the plain left-to-right
+//     ones here. Reproducing that would mean a compensated adder at every sum
+//     site, coupling this file to a CPython implementation detail that
+//     upstream's source does not state -- it just says sum(...) -- and making
+//     the translation harder to read against the original, which is the whole
+//     maintenance strategy. sdk-js made the same call.
+//
+//  2. math.Log is not bit-identical across runtimes. This shows up ONLY in
+//     percentiles whose basis is BasisTail, the exponential tail model being
+//     the sole caller of a transcendental. On one case Go's p90 lands an ULP
+//     off CPython's and JavaScript's, which agree with each other. Nothing can
+//     be done about this from inside the algorithm.
+//
+// Both are fourteen orders of magnitude below the published margin of error.
+// Neither is purely invisible: a sum landing within 1e-16 of a rounding
+// boundary can move the last digit of a warning STRING. The forecast numbers
+// are unaffected.
+//
+// Go needs no tie-breaking helper of its own: fmt rounds half to even, which is
+// what Python's format spec does. (sdk-js needs one, because toFixed rounds ties
+// away from zero.)
+//
+// One deliberate omission: upstream still carries _fit_normal, the
+// weighted-least-squares normal fit on the probit scale that the rank method
+// replaced. It is unreachable there -- nothing calls it -- so it is not
+// translated, which also spares this package an inverse-normal CDF. If it is
+// ever wired back up upstream, it has to be written here from scratch, not
+// ported.
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+const (
+	// minConfidence is the point below which a bracket contributes essentially
+	// nothing.
+	minConfidence = 1e-3
+
+	// DefaultHalfSpread completes a one-sided quote when the market gives us
+	// nothing better. The bounds keep a pathological book from imputing a silly
+	// step.
+	DefaultHalfSpread = 0.06
+	minHalfSpread     = 0.01
+	maxHalfSpread     = 0.20
+
+	// MinQuoteNotionalCentShares is the floor below which a top-of-book quote is
+	// treated as absent. Size does not enter the forecast itself, so without a
+	// floor a single tiny order at a silly price moves the published number as
+	// much as a real one: one 90c bid on a dead tail shifted a bimodal market by
+	// 8 units, for 90c of risk. Only applied when sizes are supplied; callers
+	// that pass none keep the unfiltered behaviour.
+	MinQuoteNotionalCentShares = 100
+
+	// dutchBookTolerance bounds how far the book may stray before we say so. The
+	// buckets are mutually exclusive and exhaustive, so the asks must cost at
+	// least 1 and the bids must not pay more than 1. Outside these, someone is
+	// giving money away. Warned on rather than normalised silently.
+	dutchBookTolerance = 0.02
+
+	// DepthMinSideNotionalUSD applies to the depth path only. A side whose ENTIRE
+	// ladder holds less than this many dollars is treated as absent: with the
+	// full book summed, dust cannot hide in front of a real order, so a small
+	// floor is enough to make sub-dollar griefing quotes weightless. Tunable.
+	DepthMinSideNotionalUSD = 5.0
+
+	// LowTotalNotionalWarnUSD is a disclosure threshold only, never part of the
+	// math: a market whose books hold less than this in total gets a warning
+	// attached, because relative standardisation cannot see absolute poverty.
+	LowTotalNotionalWarnUSD = 50.0
+
+	// PeakProminence is the fraction of the tallest peak a second density peak
+	// must reach to count as real multimodality; below it is quote noise.
+	PeakProminence = 0.20
+)
+
+// Basis values, recording where a percentile came from and therefore how far to
+// trust it.
+const (
+	// BasisInterior means the value was read between real strikes with no shape
+	// assumption.
+	BasisInterior = "interior"
+	// BasisTail means the value fell inside an open-ended outer bucket and rests
+	// on the exponential tail model.
+	BasisTail = "tail"
+	// BasisUnresolved means the market has too few strikes to place the value.
+	BasisUnresolved = "unresolved"
+)
+
+// Method values, recording how the point estimate was produced.
+const (
+	// MethodRank is the normal path: percentiles read off the implied CDF.
+	MethodRank = "rank"
+	// MethodDiscrete is the fallback for a book the rank read cannot handle.
+	MethodDiscrete = "discrete"
+)
+
+// Ptr returns a pointer to v. Bucket bounds and quotes are optional, so they are
+// pointers; this saves callers a temporary on every literal.
+//
+//	forecast.BucketBook{Lower: nil, Upper: forecast.Ptr(4.04)}
+func Ptr[T any](v T) *T {
+	return &v
+}
+
+// BookLevel is one resting level: price in cents (positive, 1-99), size in
+// shares.
+type BookLevel struct {
+	Price float64
+	Size  float64
+}
+
+// BucketBook is one bucket's bounds and its best two-sided quote, in cents.
+//
+// Lower/Upper are nil for the open-ended outer buckets. Prices are the positive
+// 1-99 cent convention for the bucket's YES side; nil means no resting order on
+// that side.
+type BucketBook struct {
+	Lower   *float64
+	Upper   *float64
+	BestBid *float64
+	BestAsk *float64
+	QueryID *int
+	// BidSize and AskSize are the shares at the best quote. Supply them to
+	// enable the dust floor; leave them nil to skip it.
+	BidSize *float64
+	AskSize *float64
+}
+
+// usableQuote drops a top-of-book quote too small to mean anything.
+//
+// LIMITATION: this only sees the best level. If a dust order is sitting in front
+// of a real one, dropping it here marks the whole bucket unpriced rather than
+// falling back to the real quote behind it, which can be worse than not
+// filtering at all. Callers that hold the full book should instead pass the best
+// level whose size clears the floor, and leave the size fields nil. This is a
+// backstop, not the fix.
+func usableQuote(price, size *float64) *float64 {
+	if price == nil || size == nil {
+		return price
+	}
+	if *price*(*size) >= MinQuoteNotionalCentShares {
+		return price
+	}
+	return nil
+}
+
+// UsableBid returns the best bid, or nil when it is absent or below the dust
+// floor.
+func (b BucketBook) UsableBid() *float64 { return usableQuote(b.BestBid, b.BidSize) }
+
+// UsableAsk returns the best ask, or nil when it is absent or below the dust
+// floor.
+func (b BucketBook) UsableAsk() *float64 { return usableQuote(b.BestAsk, b.AskSize) }
+
+// BucketDepth is one bucket's FULL ladders on all four sides.
+//
+// The YES and NO books are consolidated inside this package because the
+// inversion is executable, not merely informative. Verified on testnet
+// (2026-08-03): the protocol's fill hierarchy matches EXACT inverses. A resting
+// BUY NO at p mint-matches an incoming BUY YES at 100-p (one pair minted for
+// $1), and a resting SELL NO at p burn-matches an incoming SELL YES at 100-p
+// (one pair merged for $1). So:
+//
+//	consolidated bids = YesBids + (100 - p for every NO ask)
+//	consolidated asks = YesAsks + (100 - p for every NO bid)
+//
+// both sides hittable at exactly the inverted price. There is no
+// price-improvement crossing: near-inverses (sums other than 100) rest.
+type BucketDepth struct {
+	Lower   *float64
+	Upper   *float64
+	YesBids []BookLevel
+	YesAsks []BookLevel
+	NoBids  []BookLevel
+	NoAsks  []BookLevel
+	QueryID *int
+}
+
+// round4 keeps the inverted cent prices off float dust.
+func round4(v float64) float64 { return math.Round(v*1e4) / 1e4 }
+
+// ConsolidatedBids returns the bucket's executable bid ladder: its YES bids plus
+// every NO ask inverted to the YES price it is hittable at, best (highest)
+// first.
+func (d BucketDepth) ConsolidatedBids() []BookLevel {
+	levels := make([]BookLevel, 0, len(d.YesBids)+len(d.NoAsks))
+	for _, l := range d.YesBids {
+		if l.Size > 0 {
+			levels = append(levels, l)
+		}
+	}
+	for _, l := range d.NoAsks {
+		if l.Size > 0 {
+			levels = append(levels, BookLevel{Price: round4(100 - l.Price), Size: l.Size})
+		}
+	}
+	sort.SliceStable(levels, func(i, j int) bool { return levels[i].Price > levels[j].Price })
+	return levels
+}
+
+// ConsolidatedAsks returns the bucket's executable ask ladder: its YES asks plus
+// every NO bid inverted to the YES price it is hittable at, best (lowest) first.
+func (d BucketDepth) ConsolidatedAsks() []BookLevel {
+	levels := make([]BookLevel, 0, len(d.YesAsks)+len(d.NoBids))
+	for _, l := range d.YesAsks {
+		if l.Size > 0 {
+			levels = append(levels, l)
+		}
+	}
+	for _, l := range d.NoBids {
+		if l.Size > 0 {
+			levels = append(levels, BookLevel{Price: round4(100 - l.Price), Size: l.Size})
+		}
+	}
+	sort.SliceStable(levels, func(i, j int) bool { return levels[i].Price < levels[j].Price })
+	return levels
+}
+
+// BestView returns the consolidated best quotes, for the spread and dutch-book
+// helpers.
+func (d BucketDepth) BestView() BucketBook {
+	bids, asks := d.ConsolidatedBids(), d.ConsolidatedAsks()
+	view := BucketBook{Lower: d.Lower, Upper: d.Upper, QueryID: d.QueryID}
+	if len(bids) > 0 {
+		view.BestBid = Ptr(bids[0].Price)
+	}
+	if len(asks) > 0 {
+		view.BestAsk = Ptr(asks[0].Price)
+	}
+	return view
+}
+
+// BucketEstimate is what one bucket's book implies about its probability.
+type BucketEstimate struct {
+	QueryID *int
+	Lower   *float64
+	Upper   *float64
+	// Probability is normalised; it sums to 1 across the market.
+	Probability float64
+	// RawProbability is the value before normalisation.
+	RawProbability float64
+	// Confidence runs 0 (no usable quote) to 1 (tight two-sided).
+	Confidence float64
+	OneSided   bool
+	Quoted     bool
+}
+
+// MarketForecast is the single value a market's order books imply.
+//
+// Value is the MEDIAN of the implied distribution. P10/P90 are the published
+// band. Each carries a basis flag: BasisInterior means it was read between real
+// strikes with no shape assumption; BasisTail means it fell inside an
+// open-ended outer bucket and rests on the exponential tail model;
+// BasisUnresolved means the market has too few strikes to place it at all.
+//
+// MarginOfError is kept for downstream compatibility as half the P10..P90 band;
+// Sigma as the band scaled to a normal-equivalent standard deviation
+// (band / 2.5631). Prefer the quantiles directly.
+type MarketForecast struct {
+	Value float64
+	// MarginOfError is half the P10..P90 band. NOT a standard error.
+	MarginOfError float64
+	Sigma         float64
+	Method        string
+	Buckets       []BucketEstimate
+	Warnings      []string
+	P10           *float64
+	P90           *float64
+	ValueBasis    string
+	P10Basis      string
+	P90Basis      string
+	Multimodal    bool
+	NPeaks        int
+}
+
+// Low returns Value - MarginOfError.
+func (f MarketForecast) Low() float64 { return f.Value - f.MarginOfError }
+
+// High returns Value + MarginOfError.
+func (f MarketForecast) High() float64 { return f.Value + f.MarginOfError }
+
+// AsMap returns the flat form, for SDKs and the indexer.
+func (f MarketForecast) AsMap() map[string]any {
+	probabilities := make([]float64, len(f.Buckets))
+	for i, b := range f.Buckets {
+		probabilities[i] = b.Probability
+	}
+	warnings := make([]string, len(f.Warnings))
+	copy(warnings, f.Warnings)
+	return map[string]any{
+		"value":           f.Value,
+		"value_basis":     f.ValueBasis,
+		"p10":             f.P10,
+		"p90":             f.P90,
+		"p10_basis":       f.P10Basis,
+		"p90_basis":       f.P90Basis,
+		"margin_of_error": f.MarginOfError,
+		"low":             f.Low(),
+		"high":            f.High(),
+		"sigma":           f.Sigma,
+		"method":          f.Method,
+		"multimodal":      f.Multimodal,
+		"probabilities":   probabilities,
+		"warnings":        warnings,
+	}
+}
+
+// clamp01 pins a probability into [0, 1].
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+// grouped0 renders a dollar amount with thousands separators, matching Python's
+// "{:,.0f}". Go's fmt has no grouping verb.
+func grouped0(v float64) string {
+	s := fmt.Sprintf("%.0f", v)
+	neg := strings.HasPrefix(s, "-")
+	s = strings.TrimPrefix(s, "-")
+	var out []byte
+	for i, c := range []byte(s) {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, c)
+	}
+	if neg {
+		return "-" + string(out)
+	}
+	return string(out)
+}
+
+// TypicalHalfSpread returns half the market's median two-sided spread, as a
+// probability.
+//
+// Used to complete one-sided quotes. A missing side is usually an artifact of
+// the market maker's own quoting (no inventory to sell, or the self-cross guard
+// suppressing a leg) rather than a statement about probability, so the other
+// side is still informative once shifted by the spread this market actually
+// trades.
+func TypicalHalfSpread(buckets []BucketBook) float64 {
+	var spreads []float64
+	for _, b := range buckets {
+		if b.BestBid == nil || b.BestAsk == nil || *b.BestAsk < *b.BestBid {
+			continue
+		}
+		spreads = append(spreads, (*b.BestAsk-*b.BestBid)/100)
+	}
+	if len(spreads) == 0 {
+		return DefaultHalfSpread
+	}
+	sort.Float64s(spreads)
+	mid := len(spreads) / 2
+	var median float64
+	if len(spreads)%2 == 1 {
+		median = spreads[mid]
+	} else {
+		median = (spreads[mid-1] + spreads[mid]) / 2
+	}
+	return math.Max(minHalfSpread, math.Min(median/2, maxHalfSpread))
+}
+
+// BucketProbability turns one bucket's best quote into a probability,
+// confidence and flags.
+//
+// Two-sided is the easy case: the mid, with confidence from how tight the
+// spread is.
+//
+// One-sided needs care. Treating a lone 1c bid as the midpoint of [0.01, 1.0]
+// would call it a coin flip, which is badly wrong: on real mainnet books the
+// open tail buckets are frequently bid-only at a penny, and the midpoint rule
+// handed them 27% each and buried the actual distribution. The quoted side is
+// the only real information, so we take it and step across by the market's own
+// half-spread, then mark the confidence down.
+//
+// An unquoted bucket returns a nil probability. It is NOT 0.5: the caller
+// assigns it the residual probability the quoted buckets leave behind, which is
+// what the market actually implies about it.
+func BucketProbability(bestBid, bestAsk *float64, halfSpread float64) (
+	probability *float64, confidence float64, oneSided, quoted bool,
+) {
+	quoted = bestBid != nil || bestAsk != nil
+	if !quoted {
+		return nil, 0, false, false
+	}
+
+	oneSided = bestBid == nil || bestAsk == nil
+
+	if !oneSided {
+		lo := clamp01(*bestBid / 100)
+		hi := clamp01(*bestAsk / 100)
+		if hi < lo {
+			// Crossed book: bid above ask. Either stale, or free money. Keeping
+			// the midpoint at low confidence would still let the bogus
+			// probability enter the normalisation and shift every CDF point,
+			// because confidence only affects weighting. Treat it as unquoted so
+			// the caller can assign it the residual instead.
+			return nil, 0, oneSided, quoted
+		}
+		return Ptr((lo + hi) / 2), 1 - (hi - lo), oneSided, quoted
+	}
+
+	var p float64
+	if bestBid != nil {
+		p = *bestBid/100 + halfSpread
+	} else {
+		p = *bestAsk/100 - halfSpread
+	}
+	// Confidence of a two-sided book at this spread, halved: we inferred one
+	// side rather than observing it.
+	return Ptr(clamp01(p)), math.Max(minConfidence, (1-2*halfSpread)/2), oneSided, quoted
+}
+
+// bucketMeta is one bucket's identity, as assemble needs it.
+type bucketMeta struct {
+	lower   *float64
+	upper   *float64
+	queryID *int
+}
+
+// discreteFallback returns probability-weighted bucket midpoints, for when the
+// rank read cannot run.
+//
+// The open tails have no midpoint, so they are represented by their finite edge
+// pushed out by half the average interior width. Cruder than a rank read and
+// biased toward the centre, which is why it is only a fallback. Returns NaN when
+// the buckets cannot support an estimate.
+func discreteFallback(estimates []BucketEstimate, boundaries []float64) (value, sigma float64) {
+	var widths []float64
+	for i := 0; i+1 < len(boundaries); i++ {
+		widths = append(widths, boundaries[i+1]-boundaries[i])
+	}
+	pad := 0.0
+	if len(widths) > 0 {
+		var total float64
+		for _, w := range widths {
+			total += w
+		}
+		pad = total / float64(len(widths)) / 2
+	}
+
+	var points, probs []float64
+	for _, est := range estimates {
+		if est.Lower == nil && est.Upper == nil {
+			continue
+		}
+		var point float64
+		switch {
+		case est.Lower == nil:
+			point = *est.Upper - pad
+		case est.Upper == nil:
+			point = *est.Lower + pad
+		default:
+			point = (*est.Lower + *est.Upper) / 2
+		}
+		points = append(points, point)
+		probs = append(probs, est.Probability)
+	}
+
+	var total float64
+	for _, p := range probs {
+		total += p
+	}
+	if total <= 0 || len(points) == 0 {
+		return math.NaN(), math.NaN()
+	}
+
+	var weighted float64
+	for i, x := range points {
+		weighted += probs[i] * x
+	}
+	mean := weighted / total
+
+	var variance float64
+	for i, x := range points {
+		variance += probs[i] * (x - mean) * (x - mean)
+	}
+	variance /= total
+	return mean, math.Sqrt(math.Max(variance, 0))
+}
+
+// discreteMargin returns a margin of error for the discrete fallback.
+//
+// Publishing sigma here would be wrong: sigma is how uncertain the OUTCOME is,
+// not how well the book pins our estimate. The fallback also represents each
+// open tail by an invented point, so its centre is genuinely less trustworthy
+// than a rank read. Scale sigma down by the number of buckets we could actually
+// read, and floor it so a fallback can never claim to be tighter than a real
+// read.
+func discreteMargin(sigma float64, estimates []BucketEstimate) float64 {
+	quoted := 0
+	var confidence float64
+	for _, e := range estimates {
+		if e.Quoted {
+			quoted++
+		}
+		confidence += e.Confidence
+	}
+	if quoted == 0 {
+		quoted = 1
+	}
+	conf := confidence / math.Max(float64(len(estimates)), 1)
+	return sigma * (1 - 0.5*conf) / math.Sqrt(float64(quoted))
+}
+
+// dutchBookWarning reports a book that gives money away.
+//
+// Buying YES in every bucket guarantees exactly 1, so the asks must sum to at
+// least 1. Minting a pair in every bucket and selling all the YES also settles
+// at 1, so the bids must not sum to more than 1. A violation is risk-free money
+// against us.
+func dutchBookWarning(buckets []BucketBook) string {
+	asksComplete, bidsComplete := true, true
+	var askTotal, bidTotal float64
+	for _, b := range buckets {
+		ask, bid := b.UsableAsk(), b.UsableBid()
+		if ask == nil {
+			asksComplete = false
+		} else {
+			askTotal += *ask
+		}
+		if bid == nil {
+			bidsComplete = false
+		} else {
+			bidTotal += *bid
+		}
+	}
+	if asksComplete {
+		total := askTotal / 100
+		if total < 1-dutchBookTolerance {
+			return fmt.Sprintf(
+				"DUTCH BOOK: asks sum to %.3f; buying every bucket costs "+
+					"%.3f and settles at 1.000, a risk-free "+
+					"%.1fc per dollar against us", total, total, (1-total)*100)
+		}
+	}
+	if bidsComplete {
+		total := bidTotal / 100
+		if total > 1+dutchBookTolerance {
+			return fmt.Sprintf(
+				"DUTCH BOOK: bids sum to %.3f; minting and selling every "+
+					"bucket pays %.3f against a cost of 1.000, a risk-free "+
+					"%.1fc per dollar against us", total, total, (total-1)*100)
+		}
+	}
+	return ""
+}
+
+// rankQuantile reads percentile q directly off the piecewise-linear implied CDF.
+//
+// Interior crossings interpolate between real strikes and assume nothing beyond
+// uniform density within the bucket. A crossing inside an open-ended outer
+// bucket needs a shape for the tail; we use an exponential decay matched to the
+// adjacent interior bucket's density, and flag the result BasisTail so consumers
+// know it rests on that assumption. With fewer than two boundaries there is no
+// interior at all and no density to anchor a tail, so the answer is unresolved.
+func rankQuantile(bounds, probs []float64, q float64) (*float64, string) {
+	k := len(probs)
+	cum := make([]float64, 0, k-1)
+	run := 0.0
+	for i := 0; i < k-1; i++ {
+		run += probs[i]
+		cum = append(cum, run)
+	}
+	if len(bounds) < 2 {
+		return nil, BasisUnresolved
+	}
+
+	for i := 1; i < k-1; i++ { // interior buckets
+		loC, hiC := cum[i-1], cum[i]
+		if loC <= q && q <= hiC {
+			loB, hiB := bounds[i-1], bounds[i]
+			if hiC <= loC {
+				return Ptr((loB + hiB) / 2), BasisInterior
+			}
+			frac := (q - loC) / (hiC - loC)
+			return Ptr(loB + frac*(hiB-loB)), BasisInterior
+		}
+	}
+
+	widths := make([]float64, 0, len(bounds)-1)
+	for i := 0; i+1 < len(bounds); i++ {
+		widths = append(widths, bounds[i+1]-bounds[i])
+	}
+
+	if q < cum[0] { // lower open tail
+		dens := 0.0
+		if widths[0] > 0 {
+			dens = probs[1] / widths[0]
+		}
+		if dens <= 0 || cum[0] <= 0 {
+			return nil, BasisUnresolved
+		}
+		lam := dens / cum[0]
+		return Ptr(bounds[0] + math.Log(q/cum[0])/lam), BasisTail
+	}
+
+	// upper open tail
+	upperMass := probs[k-1]
+	dens := 0.0
+	if widths[len(widths)-1] > 0 {
+		dens = probs[k-2] / widths[len(widths)-1]
+	}
+	if dens <= 0 || upperMass <= 0 {
+		return nil, BasisUnresolved
+	}
+	lam := dens / upperMass
+	return Ptr(bounds[len(bounds)-1] - math.Log(math.Max(1-q, 1e-12)/upperMass)/lam), BasisTail
+}
+
+// countPeaks returns the prominent local maxima of the interior density profile.
+//
+// A peak only counts if it reaches PeakProminence of the tallest one, so a
+// penny-noise bump next to a 96% bucket does not read as bimodality. Open tails
+// carry no density profile, so tail-heavy bimodality is seen through the
+// interior buckets adjacent to the tails.
+func countPeaks(bounds, probs []float64) int {
+	dens := make([]float64, 0, len(bounds)-1)
+	for i := 0; i+1 < len(bounds); i++ {
+		w := bounds[i+1] - bounds[i]
+		if w > 0 {
+			dens = append(dens, probs[i+1]/w)
+		} else {
+			dens = append(dens, 0)
+		}
+	}
+	if len(dens) == 0 {
+		return 1
+	}
+	top := dens[0]
+	for _, d := range dens {
+		if d > top {
+			top = d
+		}
+	}
+	if top <= 0 {
+		return 1
+	}
+	peaks := 0
+	for i, d := range dens {
+		isMax := (i == 0 || d > dens[i-1]) && (i == len(dens)-1 || d >= dens[i+1])
+		if isMax && d >= PeakProminence*top {
+			peaks++
+		}
+	}
+	if peaks < 1 {
+		return 1
+	}
+	return peaks
+}
+
+// assemble is the shared back half of the pipeline: normalise the per-bucket
+// estimates, build the implied CDF, read the percentiles off it, or fall back.
+//
+// bidsCents is each bucket's best bid, used only to bound what an unpriced
+// bucket could claim.
+func assemble(
+	meta []bucketMeta,
+	bidsCents []*float64,
+	raw []*float64,
+	confs []float64,
+	oneSidedFlags []bool,
+	quotedFlags []bool,
+	warnings []string,
+) *MarketForecast {
+	anyQuoted := false
+	nUnquoted := 0
+	for _, q := range quotedFlags {
+		if q {
+			anyQuoted = true
+		} else {
+			nUnquoted++
+		}
+	}
+	if !anyQuoted {
+		return nil
+	}
+
+	nMissing := 0
+	for _, p := range raw {
+		if p == nil {
+			nMissing++
+		}
+	}
+	nCrossed := nMissing - nUnquoted
+	nOneSided := 0
+	for _, o := range oneSidedFlags {
+		if o {
+			nOneSided++
+		}
+	}
+
+	if nUnquoted > 0 {
+		warnings = append(warnings, fmt.Sprintf("%d of %d buckets unquoted", nUnquoted, len(meta)))
+	}
+	if nCrossed > 0 {
+		warnings = append(warnings, fmt.Sprintf(
+			"%d bucket(s) crossed (bid above ask); treated as unpriced", nCrossed))
+	}
+	if nOneSided > 0 {
+		warnings = append(warnings, fmt.Sprintf(
+			"%d bucket(s) one-sided; margin of error widened", nOneSided))
+	}
+
+	var quotedTotal float64
+	for _, p := range raw {
+		if p != nil {
+			quotedTotal += *p
+		}
+	}
+	if quotedTotal <= 0 {
+		return nil
+	}
+	if math.Abs(quotedTotal-1) > dutchBookTolerance {
+		// Independent books never sum to exactly 1. Report the SIGNED deviation
+		// rather than a wide dead band: the direction says whether the book is
+		// over- or under-priced, and a wide window hides real boxes.
+		warnings = append(warnings, fmt.Sprintf(
+			"bucket mids sum to %.3f (%+.1fc per dollar) before normalising",
+			quotedTotal, (quotedTotal-1)*100))
+	}
+
+	filled := make([]float64, len(raw))
+	if nMissing > 0 {
+		// An unpriced bucket is UNKNOWN, not impossible. Its probability is
+		// bounded above by whatever the other buckets' BIDS do not already
+		// claim, since bids are a lower bound on their true probabilities. Take
+		// the midpoint of that interval. Asserting zero is a strong claim the
+		// book never made.
+		var bidClaim float64
+		for i, p := range raw {
+			if p != nil && bidsCents[i] != nil {
+				bidClaim += *bidsCents[i] / 100
+			}
+		}
+		headroom := math.Max(0, 1-bidClaim)
+		est := headroom / (2 * float64(nMissing))
+		for i, p := range raw {
+			if p == nil {
+				filled[i] = est
+			} else {
+				filled[i] = *p
+			}
+		}
+	} else {
+		for i, p := range raw {
+			filled[i] = *p
+		}
+	}
+
+	var total float64
+	for _, p := range filled {
+		total += p
+	}
+	if total <= 0 {
+		return nil
+	}
+	probs := make([]float64, len(filled))
+	for i, p := range filled {
+		probs[i] = p / total
+	}
+
+	estimates := make([]BucketEstimate, len(meta))
+	for i, m := range meta {
+		rawProbability := 0.0
+		if raw[i] != nil {
+			rawProbability = *raw[i]
+		}
+		estimates[i] = BucketEstimate{
+			QueryID:        m.queryID,
+			Lower:          m.lower,
+			Upper:          m.upper,
+			Probability:    probs[i],
+			RawProbability: rawProbability,
+			Confidence:     confs[i],
+			OneSided:       oneSidedFlags[i],
+			Quoted:         quotedFlags[i],
+		}
+	}
+
+	var bounds []float64
+	for _, m := range meta[:len(meta)-1] {
+		if m.upper != nil {
+			bounds = append(bounds, *m.upper)
+		}
+	}
+
+	fallback := func() *MarketForecast {
+		value, sigma := discreteFallback(estimates, bounds)
+		if math.IsNaN(value) {
+			return nil
+		}
+		return &MarketForecast{
+			Value:         value,
+			MarginOfError: discreteMargin(sigma, estimates),
+			Sigma:         sigma,
+			Method:        MethodDiscrete,
+			Buckets:       estimates,
+			Warnings:      warnings,
+			ValueBasis:    BasisInterior,
+			P10Basis:      BasisInterior,
+			P90Basis:      BasisInterior,
+			NPeaks:        1,
+		}
+	}
+
+	if len(bounds) != len(meta)-1 {
+		warnings = append(warnings, "bucket bounds incomplete; falling back to discrete estimate")
+		return fallback()
+	}
+
+	// Rank method: read the percentiles straight off the implied CDF.
+	med, medBasis := rankQuantile(bounds, probs, 0.50)
+	p10, p10Basis := rankQuantile(bounds, probs, 0.10)
+	p90, p90Basis := rankQuantile(bounds, probs, 0.90)
+
+	if med == nil {
+		warnings = append(warnings,
+			"median unresolvable from these strikes; falling back to discrete estimate")
+		return fallback()
+	}
+
+	if medBasis == BasisTail {
+		outside := probs[len(probs)-1]
+		if probs[0] >= 0.5 {
+			outside = probs[0]
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"median lies beyond the outer strikes (%.0f%% of mass in an "+
+				"open-ended bucket); value depends on the assumed tail shape",
+			outside*100))
+	}
+	for _, pair := range []struct {
+		name  string
+		basis string
+	}{{"p10", p10Basis}, {"p90", p90Basis}} {
+		switch pair.basis {
+		case BasisTail:
+			warnings = append(warnings, pair.name+" falls in an open tail; tail-model dependent")
+		case BasisUnresolved:
+			warnings = append(warnings, pair.name+" unresolvable from these strikes")
+		}
+	}
+
+	nPeaks := countPeaks(bounds, probs)
+	multimodal := nPeaks >= 2
+	if multimodal {
+		warnings = append(warnings, fmt.Sprintf(
+			"market shows %d probability clusters; a single point forecast "+
+				"misrepresents it, publish the clusters instead", nPeaks))
+	}
+
+	var margin, sigma float64
+	if p10 != nil && p90 != nil {
+		band := math.Max(*p90-*p10, 0)
+		margin = band / 2
+		sigma = band / 2.5631 // P10..P90 of a normal spans 2.5631 sigma
+	} else {
+		warnings = append(warnings, "band unresolvable; margin and sigma reported as 0")
+	}
+
+	return &MarketForecast{
+		Value:         *med,
+		MarginOfError: margin,
+		Sigma:         sigma,
+		Method:        MethodRank,
+		Buckets:       estimates,
+		Warnings:      warnings,
+		P10:           p10,
+		P90:           p90,
+		ValueBasis:    medBasis,
+		P10Basis:      p10Basis,
+		P90Basis:      p90Basis,
+		Multimodal:    multimodal,
+		NPeaks:        nPeaks,
+	}
+}
+
+// FromBuckets collapses one market's bucket books into a single implied value,
+// from best quotes only.
+//
+// Buckets must be supplied in ascending order and span the whole line, with the
+// first open below and the last open above. Returns nil when the book carries no
+// usable information at all. When full ladders are available, prefer FromDepth,
+// which weights by committed notional.
+func FromBuckets(buckets []BucketBook) *MarketForecast {
+	var warnings []string
+
+	if len(buckets) < 2 {
+		return nil
+	}
+
+	half := TypicalHalfSpread(buckets)
+
+	if dutch := dutchBookWarning(buckets); dutch != "" {
+		warnings = append(warnings, dutch)
+	}
+
+	raw := make([]*float64, len(buckets))
+	confs := make([]float64, len(buckets))
+	oneSidedFlags := make([]bool, len(buckets))
+	quotedFlags := make([]bool, len(buckets))
+	meta := make([]bucketMeta, len(buckets))
+	bidsCents := make([]*float64, len(buckets))
+	for i, b := range buckets {
+		p, conf, oneSided, quoted := BucketProbability(b.UsableBid(), b.UsableAsk(), half)
+		raw[i] = p
+		confs[i] = conf
+		oneSidedFlags[i] = oneSided
+		quotedFlags[i] = quoted
+		meta[i] = bucketMeta{lower: b.Lower, upper: b.Upper, queryID: b.QueryID}
+		bidsCents[i] = b.UsableBid()
+	}
+
+	return assemble(meta, bidsCents, raw, confs, oneSidedFlags, quotedFlags, warnings)
+}
+
+// sideStats returns the VWAP in cents, the notional in dollars, and the shares
+// over a full ladder.
+//
+// The full-ladder VWAP no longer prices anything (see walkPrice); dollars are
+// the currency for confidence and the dust floors, since posting many shares of
+// a cheap side is not the same commitment as posting the same dollars.
+func sideStats(levels []BookLevel) (vwapCents, notionalUSD, shares float64) {
+	var centShares float64
+	for _, l := range levels {
+		centShares += l.Price * l.Size
+		shares += l.Size
+	}
+	return centShares / shares, centShares / 100, shares
+}
+
+// walkPrice returns the dollar-weighted price of executing targetUSD from the
+// touch.
+//
+// Walk the ladder best-first, consuming each level's own notional until the
+// target is reached; the last level fills partially. Each committed dollar
+// carries the same weight regardless of the price it rests at, which is the
+// whole point: per-dollar influence must not depend on denomination, or penny
+// ladders (25 shares per dollar at 4c) out-vote real money.
+//
+// Callers guarantee the ladder holds at least targetUSD in total (the side
+// floor); if it somehow does not, the walk prices what is there.
+func walkPrice(levels []BookLevel, targetUSD float64) float64 {
+	remaining := targetUSD * 100 // cent-shares
+	var weighted, taken float64
+	for _, l := range levels {
+		if remaining <= 0 {
+			break
+		}
+		take := math.Min(l.Price*l.Size, remaining)
+		weighted += take * l.Price
+		taken += take
+		remaining -= take
+	}
+	return weighted / taken
+}
+
+// EstimateFromDepth returns one bucket's implied probability from its full
+// consolidated ladders.
+//
+// The probability is the midpoint of the two executable walk prices: the
+// dollar-weighted price of selling DepthMinSideNotionalUSD into the consolidated
+// bids and of buying the same from the consolidated asks, clamped into
+// [best bid, best ask]. A book only pins the truth to that interval, so the
+// estimate must be a selection from it; depth beyond the first walk dollars is
+// inventory, not opinion, and moves confidence only.
+//
+// This replaced a full-book share-weighted microprice, which let cheap ladders
+// out-vote real money (a dollar at 4c is 25 shares, at 30c it is 3) and on live
+// books pushed every sub-50c bucket above its own best ask (prediction-bots
+// issue #36). Ladder imbalance moves the walk mid not at all: on this venue all
+// resting flow is the market maker's own, so imbalance carries no information
+// and would only be a free manipulation lever.
+//
+// quality is the spread component of confidence: (1 - spread) two-sided, halved
+// for a one-sided book whose missing side was inferred. notionalUSD is the
+// committed dollars backing the estimate: the THINNER side when both exist, the
+// quoted side otherwise. The caller standardises notional against the market's
+// own median depth to finish the confidence; no external constant is involved.
+//
+// Sides whose whole ladder holds under DepthMinSideNotionalUSD are treated as
+// absent: with the full book summed, dust cannot hide in front of a real order.
+// Trades are deliberately NOT used: resting depth is live, at-risk capital, and
+// the venue's only taker is a designed noise trader.
+func EstimateFromDepth(depth BucketDepth, halfSpread float64) (
+	probability *float64, quality, notionalUSD float64, oneSided, quoted bool,
+) {
+	bids := depth.ConsolidatedBids()
+	asks := depth.ConsolidatedAsks()
+	var bidNotional, askNotional float64
+
+	if len(bids) > 0 {
+		_, bidNotional, _ = sideStats(bids)
+		if bidNotional < DepthMinSideNotionalUSD {
+			bids, bidNotional = nil, 0
+		}
+	}
+	if len(asks) > 0 {
+		_, askNotional, _ = sideStats(asks)
+		if askNotional < DepthMinSideNotionalUSD {
+			asks, askNotional = nil, 0
+		}
+	}
+
+	quoted = len(bids) > 0 || len(asks) > 0
+	if !quoted {
+		return nil, 0, 0, false, false
+	}
+	oneSided = !(len(bids) > 0 && len(asks) > 0)
+
+	if !oneSided {
+		bestBid, bestAsk := bids[0].Price, asks[0].Price
+		if bestBid >= bestAsk {
+			// Crossed at the consolidated touch: stale or free money.
+			return nil, 0, 0, oneSided, quoted
+		}
+		walkBid := walkPrice(bids, DepthMinSideNotionalUSD)
+		walkAsk := walkPrice(asks, DepthMinSideNotionalUSD)
+		p := (walkBid + walkAsk) / 2
+		p = math.Max(bestBid, math.Min(bestAsk, p)) / 100
+		spread := (bestAsk - bestBid) / 100
+		return Ptr(clamp01(p)),
+			math.Max(1-spread, minConfidence),
+			math.Min(bidNotional, askNotional),
+			oneSided, quoted
+	}
+
+	var p, notional float64
+	if len(bids) > 0 {
+		p = walkPrice(bids, DepthMinSideNotionalUSD)/100 + halfSpread
+		notional = bidNotional
+	} else {
+		p = walkPrice(asks, DepthMinSideNotionalUSD)/100 - halfSpread
+		notional = askNotional
+	}
+	q := (1 - 2*halfSpread) / 2
+	return Ptr(clamp01(p)), math.Max(q, minConfidence), notional, oneSided, quoted
+}
+
+// FromDepth collapses one market's bucket books into a single implied value,
+// using FULL YES and NO ladders weighted by committed notional.
+//
+// This is the preferred entry point. The YES/NO consolidation happens here, per
+// bucket, because the inversion is executable on this venue (exact inverse
+// mint/burn matching, verified on testnet 2026-08-03), so callers should not
+// have to know the rule.
+func FromDepth(buckets []BucketDepth) *MarketForecast {
+	var warnings []string
+
+	if len(buckets) < 2 {
+		return nil
+	}
+
+	views := make([]BucketBook, len(buckets))
+	for i, b := range buckets {
+		views[i] = b.BestView()
+	}
+	half := TypicalHalfSpread(views)
+
+	if dutch := dutchBookWarning(views); dutch != "" {
+		warnings = append(warnings, dutch)
+	}
+
+	raw := make([]*float64, len(buckets))
+	qualities := make([]float64, len(buckets))
+	notionals := make([]float64, len(buckets))
+	oneSidedFlags := make([]bool, len(buckets))
+	quotedFlags := make([]bool, len(buckets))
+	for i, b := range buckets {
+		p, quality, nUSD, oneSided, quoted := EstimateFromDepth(b, half)
+		raw[i] = p
+		qualities[i] = quality
+		notionals[i] = nUSD
+		oneSidedFlags[i] = oneSided
+		quotedFlags[i] = quoted
+	}
+
+	// Confidence = quality * min(1, n / median(n)), the market standardised
+	// against its own depth. Median rather than max or sum so a single whale
+	// bucket cannot crush its siblings' credibility.
+	var pricedN []float64
+	for i, n := range notionals {
+		if raw[i] != nil && n > 0 {
+			pricedN = append(pricedN, n)
+		}
+	}
+	sort.Float64s(pricedN)
+	medN := 0.0
+	if len(pricedN) > 0 {
+		mid := len(pricedN) / 2
+		if len(pricedN)%2 == 1 {
+			medN = pricedN[mid]
+		} else {
+			medN = (pricedN[mid-1] + pricedN[mid]) / 2
+		}
+	}
+	confs := make([]float64, len(buckets))
+	for i, p := range raw {
+		switch {
+		case p == nil:
+			confs[i] = 0
+		case medN > 0:
+			confs[i] = math.Max(qualities[i]*math.Min(1, notionals[i]/medN), minConfidence)
+		default:
+			confs[i] = qualities[i]
+		}
+	}
+
+	// Disclosure, never math: relative standardisation cannot see absolute
+	// poverty, so a market that is thin EVERYWHERE gets a visible caveat.
+	var totalUSD float64
+	for _, b := range buckets {
+		for _, side := range [][]BookLevel{b.ConsolidatedBids(), b.ConsolidatedAsks()} {
+			if len(side) > 0 {
+				_, notional, _ := sideStats(side)
+				totalUSD += notional
+			}
+		}
+	}
+	if totalUSD < LowTotalNotionalWarnUSD {
+		warnings = append(warnings, fmt.Sprintf(
+			"total resting notional only $%s across all buckets", grouped0(totalUSD)))
+	}
+
+	meta := make([]bucketMeta, len(buckets))
+	bidsCents := make([]*float64, len(buckets))
+	for i, b := range buckets {
+		meta[i] = bucketMeta{lower: b.Lower, upper: b.Upper, queryID: b.QueryID}
+		bidsCents[i] = views[i].BestBid
+	}
+
+	return assemble(meta, bidsCents, raw, confs, oneSidedFlags, quotedFlags, warnings)
+}

--- a/core/forecast/forecast_depth_test.go
+++ b/core/forecast/forecast_depth_test.go
@@ -346,6 +346,37 @@ func TestFromDepth_AllEmptyReturnsNil(t *testing.T) {
 	assert.Nil(t, FromDepth(empty))
 }
 
+func TestFromDepth_ThinMarketIsDisclosed(t *testing.T) {
+	// Relative standardisation compares each bucket to its own market's median
+	// depth, so it cannot see a market that is poor EVERYWHERE. That gets a
+	// warning instead, which is also the only exercise grouped0 gets.
+	// Threading a narrow window: six consolidated sides each need to clear the
+	// $5 side floor to stay quoted, which puts the floor of a fully quoted
+	// market at $30, and the total has to land under the $50 warning line.
+	// These sizes give $37.50 spread as 5.45/5.81, 5.27/5.99, 5.10/9.90.
+	thin := buildDepth(cents(62.5, 31.25, 6.25), []float64{1.5, 3, 20}, threeBounds)
+	f := FromDepth(thin)
+	require.NotNil(t, f)
+	assert.True(t, hasWarning(f, "total resting notional only $"),
+		"a market under LowTotalNotionalWarnUSD must say so: %v", f.Warnings)
+
+	// A market comfortably above the threshold says nothing.
+	rich := buildDepth(cents(62.5, 31.25, 6.25), []float64{5000, 5000, 5000}, threeBounds)
+	fr := FromDepth(rich)
+	require.NotNil(t, fr)
+	assert.False(t, hasWarning(fr, "total resting notional only $"))
+}
+
+func TestGrouped0_SeparatesThousands(t *testing.T) {
+	// Go's fmt has no grouping verb, so this is hand-rolled and worth pinning.
+	assert.Equal(t, "0", grouped0(0))
+	assert.Equal(t, "999", grouped0(999))
+	assert.Equal(t, "1,000", grouped0(1000))
+	assert.Equal(t, "12,345", grouped0(12345.4))
+	assert.Equal(t, "1,234,567", grouped0(1234567))
+	assert.Equal(t, "-1,234", grouped0(-1234))
+}
+
 func TestFromDepth_OneSidedBucketSurvives(t *testing.T) {
 	buckets := buildDepth(cents(62.5, 31.25, nil), nil, threeBounds)
 	// ask-only after inversion

--- a/core/forecast/forecast_depth_test.go
+++ b/core/forecast/forecast_depth_test.go
@@ -1,0 +1,401 @@
+// Tests for the depth-weighted forecast path.
+//
+// The depth path consolidates the YES and NO ladders inside the package (the
+// inversion is executable via exact-inverse mint/burn matching, verified on
+// testnet 2026-08-03) and weights each bucket by committed notional rather than
+// reading best quotes alone.
+//
+// Ported case-for-case from sdk-py's tests/test_forecast_depth.py.
+
+package forecast
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// depthBounds is the MSFT-shaped layout, as on mainnet.
+var depthBounds = msftBounds
+
+// ladder returns symmetric YES ladders plus the exact NO mirror our MM would
+// post.
+func ladder(mid float64, size float64) (yesBids, yesAsks, noBids, noAsks []BookLevel) {
+	const levels, spread, step = 3, 2.0, 1.0
+	for k := 0; k < levels; k++ {
+		yesBids = append(yesBids, BookLevel{Price: round4(mid - spread/2 - float64(k)*step), Size: size})
+		yesAsks = append(yesAsks, BookLevel{Price: round4(mid + spread/2 + float64(k)*step), Size: size})
+	}
+	for _, l := range yesAsks {
+		noBids = append(noBids, BookLevel{Price: round4(100 - l.Price), Size: l.Size})
+	}
+	for _, l := range yesBids {
+		noAsks = append(noAsks, BookLevel{Price: round4(100 - l.Price), Size: l.Size})
+	}
+	return yesBids, yesAsks, noBids, noAsks
+}
+
+// buildDepth mirrors the quote-path build helper, with full ladders.
+func buildDepth(mids []*float64, sizes []float64, bounds []bound) []BucketDepth {
+	out := make([]BucketDepth, len(bounds))
+	for i, b := range bounds {
+		out[i] = BucketDepth{Lower: b.lower, Upper: b.upper}
+		if mids[i] == nil {
+			continue
+		}
+		size := 100.0
+		if sizes != nil {
+			size = sizes[i]
+		}
+		yb, ya, nb, na := ladder(*mids[i], size)
+		out[i].YesBids, out[i].YesAsks, out[i].NoBids, out[i].NoAsks = yb, ya, nb, na
+	}
+	return out
+}
+
+var threeBounds = []bound{
+	{nil, Ptr(1.0)},
+	{Ptr(1.0), Ptr(2.0)},
+	{Ptr(2.0), nil},
+}
+
+// ═══════════════════════════════════════════════════════════════
+// CONSOLIDATION
+// ═══════════════════════════════════════════════════════════════
+
+func TestConsolidation_NoBidBecomesExecutableAsk(t *testing.T) {
+	asks := BucketDepth{
+		Lower: nil, Upper: Ptr(4.04),
+		NoBids: []BookLevel{{Price: 83, Size: 50}},
+	}.ConsolidatedAsks()
+	require.Len(t, asks, 1)
+	assert.InDelta(t, 17.0, asks[0].Price, 1e-12)
+	assert.Equal(t, 50.0, asks[0].Size)
+}
+
+func TestConsolidation_NoAskBecomesExecutableBid(t *testing.T) {
+	bids := BucketDepth{
+		Lower: nil, Upper: Ptr(4.04),
+		NoAsks: []BookLevel{{Price: 95, Size: 40}},
+	}.ConsolidatedBids()
+	require.Len(t, bids, 1)
+	assert.InDelta(t, 5.0, bids[0].Price, 1e-12)
+}
+
+func TestConsolidation_SidesAreSortedBestFirst(t *testing.T) {
+	d := BucketDepth{
+		Lower: nil, Upper: Ptr(4.04),
+		YesBids: []BookLevel{{Price: 30, Size: 10}},
+		YesAsks: []BookLevel{{Price: 40, Size: 10}},
+		NoBids:  []BookLevel{{Price: 65, Size: 10}}, // -> ask at 35, better than the YES ask
+		NoAsks:  []BookLevel{{Price: 68, Size: 10}}, // -> bid at 32, better than the YES bid
+	}
+	assert.InDelta(t, 32.0, d.ConsolidatedBids()[0].Price, 1e-12)
+	assert.InDelta(t, 35.0, d.ConsolidatedAsks()[0].Price, 1e-12)
+}
+
+// ═══════════════════════════════════════════════════════════════
+// THE WALK MID
+// ═══════════════════════════════════════════════════════════════
+
+func TestWalkMid_SymmetricDepthGivesTheMid(t *testing.T) {
+	yb, ya, nb, na := ladder(40.0, 100)
+	p, _, notional, oneSided, quoted := EstimateFromDepth(BucketDepth{
+		Lower: nil, Upper: Ptr(4.04),
+		YesBids: yb, YesAsks: ya, NoBids: nb, NoAsks: na,
+	}, DefaultHalfSpread)
+
+	require.NotNil(t, p)
+	assert.InDelta(t, 0.40, *p, 1e-6)
+	assert.True(t, quoted)
+	assert.False(t, oneSided)
+	assert.Greater(t, notional, 0.0)
+}
+
+func TestWalkMid_LadderImbalanceDoesNotMoveThePrice(t *testing.T) {
+	// Size imbalance is denomination and inventory, not opinion (issue #36): on
+	// this venue all resting flow is the MM's own, so extra size behind the walk
+	// must leave the estimate exactly where it was.
+	yb, ya, _, _ := ladder(40.0, 100)
+	heavy := make([]BookLevel, len(yb))
+	for i, l := range yb {
+		heavy[i] = BookLevel{Price: l.Price, Size: l.Size * 10}
+	}
+
+	pHeavy, _, _, _, _ := EstimateFromDepth(
+		BucketDepth{Lower: nil, Upper: Ptr(4.04), YesBids: heavy, YesAsks: ya}, DefaultHalfSpread)
+	pFlat, _, _, _, _ := EstimateFromDepth(
+		BucketDepth{Lower: nil, Upper: Ptr(4.04), YesBids: yb, YesAsks: ya}, DefaultHalfSpread)
+
+	require.NotNil(t, pHeavy)
+	require.NotNil(t, pFlat)
+	assert.InDelta(t, *pFlat, *pHeavy, 1e-12)
+}
+
+func TestWalkMid_StaysBetweenBestBidAndAsk(t *testing.T) {
+	// The book only pins the truth to [best bid, best ask]; a published
+	// probability outside the executable bracket is dutch-bookable. The old
+	// microprice gave 18.4 on this real NVDA bucket against a best ask of 17.
+	d := BucketDepth{
+		Lower: nil, Upper: Ptr(1.91),
+		YesBids: []BookLevel{{Price: 4, Size: 386}, {Price: 3, Size: 519}, {Price: 1, Size: 1558}},
+		NoBids:  []BookLevel{{Price: 83, Size: 6}, {Price: 81, Size: 25}},
+		NoAsks:  []BookLevel{{Price: 97, Size: 3}, {Price: 99, Size: 20}},
+	}
+	p, _, _, _, _ := EstimateFromDepth(d, DefaultHalfSpread)
+	require.NotNil(t, p)
+	assert.GreaterOrEqual(t, *p, d.ConsolidatedBids()[0].Price/100)
+	assert.LessOrEqual(t, *p, d.ConsolidatedAsks()[0].Price/100)
+}
+
+func TestWalkMid_FragmentedSideIsPricedNotDropped(t *testing.T) {
+	// $5.77 of real asks split across two sub-$5 levels must still price the
+	// side (the floor is on the side total, never per level), so splitting an
+	// order into small clips cannot silence a side.
+	p, _, _, oneSided, quoted := EstimateFromDepth(BucketDepth{
+		Lower: nil, Upper: Ptr(1.91),
+		YesBids: []BookLevel{{Price: 4, Size: 386}},
+		// asks at 17 ($1.02) and 19 ($4.75)
+		NoBids: []BookLevel{{Price: 83, Size: 6}, {Price: 81, Size: 25}},
+	}, DefaultHalfSpread)
+
+	require.NotNil(t, p)
+	assert.True(t, quoted)
+	assert.False(t, oneSided)
+	// sell $5 at 4c; buy $5 = $1.02 at 17 then $3.98 at 19 -> 18.59; mid 11.3
+	assert.InDelta(t, 0.113, *p, 0.001)
+}
+
+func TestWalkMid_SizeBehindTheWalkIsWeightless(t *testing.T) {
+	// 100k shares added at 1c behind the first $5 of bids must not move the
+	// estimate by a single bit.
+	yb, ya, nb, na := ladder(40.0, 100)
+	base, _, _, _, _ := EstimateFromDepth(BucketDepth{
+		Lower: nil, Upper: Ptr(4.04), YesBids: yb, YesAsks: ya, NoBids: nb, NoAsks: na,
+	}, DefaultHalfSpread)
+
+	spammed := append(append([]BookLevel{}, yb...), BookLevel{Price: 1, Size: 100000})
+	p, _, _, _, _ := EstimateFromDepth(BucketDepth{
+		Lower: nil, Upper: Ptr(4.04), YesBids: spammed, YesAsks: ya, NoBids: nb, NoAsks: na,
+	}, DefaultHalfSpread)
+
+	require.NotNil(t, base)
+	require.NotNil(t, p)
+	assert.Equal(t, *base, *p, "must be identical to the bit, not merely close")
+}
+
+func TestWalkMid_ThinTouchWalksToTheRealDepth(t *testing.T) {
+	// A $1.68 best ask cannot speak for the side alone: the $5 walk carries into
+	// the next level, blending 42 and 45 by their committed dollars.
+	p, _, _, _, _ := EstimateFromDepth(BucketDepth{
+		Lower: Ptr(2.06), Upper: Ptr(2.21),
+		YesBids: []BookLevel{{Price: 30, Size: 7}, {Price: 29, Size: 54}, {Price: 27, Size: 58}},
+		YesAsks: []BookLevel{{Price: 42, Size: 4}, {Price: 45, Size: 44}},
+	}, DefaultHalfSpread)
+
+	require.NotNil(t, p)
+	// sell $5: $2.10 at 30 + $2.90 at 29 = 29.42; buy $5: $1.68 at 42 +
+	// $3.32 at 45 = 43.99; mid 36.7
+	assert.InDelta(t, 0.367, *p, 0.001)
+}
+
+func TestWalkMid_ConfidenceIsStandardisedWithinTheMarket(t *testing.T) {
+	// Confidence compares each bucket to its OWN market's median depth, so a
+	// bucket at typical depth earns the full spread quality and a bucket at a
+	// fraction of typical depth is discounted proportionally. No external dollar
+	// constant is involved, and one whale bucket cannot crush the rest because
+	// the standard is the median.
+	f := FromDepth(buildDepth(cents(62.5, 31.25, 6.25), []float64{500, 500, 20}, threeBounds))
+	require.NotNil(t, f)
+	confs := []float64{f.Buckets[0].Confidence, f.Buckets[1].Confidence, f.Buckets[2].Confidence}
+	assert.InDelta(t, confs[1], confs[0], 1e-12)
+	assert.Less(t, confs[2], confs[1]*0.2, "the thin bucket must be discounted")
+
+	whale := FromDepth(buildDepth(cents(62.5, 31.25, 6.25), []float64{500, 50000, 500}, threeBounds))
+	require.NotNil(t, whale)
+	assert.InEpsilon(t, confs[0], whale.Buckets[0].Confidence, 0.05,
+		"a whale in one bucket must not crush its siblings' confidence")
+}
+
+// ═══════════════════════════════════════════════════════════════
+// THE ISSUE #36 BOOK, FROZEN
+// ═══════════════════════════════════════════════════════════════
+
+// nvdaFrozen is the live NVDA EPS book of 2026-08-03. Under the old
+// share-weighted microprice the five raw estimates summed to 1.359 and two
+// buckets priced above their own best ask. The walk mid must keep every bucket
+// inside its touch and the raw sum near 1 (spread-wide, not ladder-wide).
+var nvdaFrozen = []BucketDepth{
+	{
+		Lower: nil, Upper: Ptr(1.91),
+		YesBids: []BookLevel{{Price: 4, Size: 386}, {Price: 3, Size: 519}, {Price: 1, Size: 1558}},
+		NoBids:  []BookLevel{{Price: 83, Size: 6}, {Price: 81, Size: 25}},
+		NoAsks:  []BookLevel{{Price: 97, Size: 3}, {Price: 99, Size: 20}},
+	},
+	{
+		Lower: Ptr(1.91), Upper: Ptr(2.06),
+		YesBids: []BookLevel{{Price: 17, Size: 96}, {Price: 16, Size: 18}, {Price: 14, Size: 122}},
+		NoBids:  []BookLevel{{Price: 70, Size: 19}, {Price: 68, Size: 29}},
+		NoAsks:  []BookLevel{{Price: 84, Size: 5}},
+	},
+	{
+		Lower: Ptr(2.06), Upper: Ptr(2.21),
+		YesBids: []BookLevel{{Price: 30, Size: 7}, {Price: 29, Size: 54}, {Price: 27, Size: 58}},
+		YesAsks: []BookLevel{{Price: 42, Size: 4}, {Price: 45, Size: 44}},
+		NoBids:  []BookLevel{{Price: 57, Size: 7}, {Price: 55, Size: 28}},
+		NoAsks:  []BookLevel{{Price: 70, Size: 16}},
+	},
+	{
+		Lower: Ptr(2.21), Upper: Ptr(2.35),
+		YesBids: []BookLevel{{Price: 15, Size: 62}, {Price: 14, Size: 111}, {Price: 12, Size: 130}},
+		YesAsks: []BookLevel{{Price: 27, Size: 35}},
+		NoBids:  []BookLevel{{Price: 72, Size: 16}, {Price: 70, Size: 29}},
+		NoAsks:  []BookLevel{{Price: 99, Size: 6}},
+	},
+	{
+		Lower: Ptr(2.35), Upper: nil,
+		YesBids: []BookLevel{{Price: 4, Size: 499}, {Price: 3, Size: 667}, {Price: 1, Size: 2000}},
+		NoBids:  []BookLevel{{Price: 75, Size: 37}, {Price: 74, Size: 24}, {Price: 73, Size: 51}},
+		NoAsks:  []BookLevel{{Price: 97, Size: 3}, {Price: 99, Size: 20}},
+	},
+}
+
+func TestFrozenBook_EveryBucketInsideItsTouch(t *testing.T) {
+	for _, d := range nvdaFrozen {
+		p, _, _, _, _ := EstimateFromDepth(d, DefaultHalfSpread)
+		require.NotNil(t, p)
+		assert.GreaterOrEqual(t, *p, d.ConsolidatedBids()[0].Price/100)
+		assert.LessOrEqual(t, *p, d.ConsolidatedAsks()[0].Price/100)
+	}
+}
+
+func TestFrozenBook_RawSumIsSpreadWideNotInflated(t *testing.T) {
+	var total, lo, hi float64
+	for _, d := range nvdaFrozen {
+		p, _, _, _, _ := EstimateFromDepth(d, DefaultHalfSpread)
+		require.NotNil(t, p)
+		total += *p
+		lo += d.ConsolidatedBids()[0].Price
+		hi += d.ConsolidatedAsks()[0].Price
+	}
+	assert.GreaterOrEqual(t, total, lo/100)
+	assert.LessOrEqual(t, total, hi/100)
+	assert.Less(t, total, 1.10, "was 1.359 under the microprice")
+}
+
+// ═══════════════════════════════════════════════════════════════
+// GRIEFING
+// ═══════════════════════════════════════════════════════════════
+
+var griefBounds = []bound{
+	{nil, Ptr(-2.0)},
+	{Ptr(-2.0), Ptr(-1.0)},
+	{Ptr(-1.0), Ptr(1.0)},
+	{Ptr(1.0), Ptr(2.0)},
+	{Ptr(2.0), nil},
+}
+
+func TestGriefing_DustLadderIsWeightless(t *testing.T) {
+	// A 1-share 90c bid on a dead tail moved the old estimator by 8 units.
+	// Summed over the full book it is $0.90, under the side floor, so absent.
+	base := buildDepth(cents(45, 5, 1, 5, 45), nil, griefBounds)
+	f0 := FromDepth(base)
+	require.NotNil(t, f0)
+
+	griefed := append([]BucketDepth{}, base...)
+	griefed[4] = BucketDepth{
+		Lower: Ptr(2.0), Upper: nil,
+		YesBids: []BookLevel{{Price: 90, Size: 1}},
+	}
+	f1 := FromDepth(griefed)
+	require.NotNil(t, f1)
+
+	// the dusted bucket must contribute exactly what an unquoted one would
+	unquoted := FromDepth(append(append([]BucketDepth{}, base[:4]...),
+		BucketDepth{Lower: Ptr(2.0), Upper: nil}))
+	require.NotNil(t, unquoted)
+	assert.InDelta(t, unquoted.Value, f1.Value, 1e-12)
+	assert.Less(t, math.Abs(f1.Value-f0.Value), 8.0, "must not swing like before")
+}
+
+func TestGriefing_RealSizeAtTheSamePriceDoesCount(t *testing.T) {
+	base := buildDepth(cents(45, 5, 1, 5, 45), nil, griefBounds)
+	sized := append([]BucketDepth{}, base...)
+	sized[4] = BucketDepth{
+		Lower: Ptr(2.0), Upper: nil,
+		YesBids: []BookLevel{{Price: 90, Size: 50}}, // $45 resting
+	}
+
+	f0, f1 := FromDepth(base), FromDepth(sized)
+	require.NotNil(t, f0)
+	require.NotNil(t, f1)
+	assert.Greater(t, math.Abs(f1.Value-f0.Value), 1e-6, "a funded quote must matter")
+}
+
+// ═══════════════════════════════════════════════════════════════
+// DEGENERATE INPUT
+// ═══════════════════════════════════════════════════════════════
+
+func TestFromDepth_AllEmptyReturnsNil(t *testing.T) {
+	empty := make([]BucketDepth, len(depthBounds))
+	for i, b := range depthBounds {
+		empty[i] = BucketDepth{Lower: b.lower, Upper: b.upper}
+	}
+	assert.Nil(t, FromDepth(empty))
+}
+
+func TestFromDepth_OneSidedBucketSurvives(t *testing.T) {
+	buckets := buildDepth(cents(62.5, 31.25, nil), nil, threeBounds)
+	// ask-only after inversion
+	buckets[2] = BucketDepth{
+		Lower: Ptr(2.0), Upper: nil,
+		NoBids: []BookLevel{{Price: 93, Size: 100}},
+	}
+	f := FromDepth(buckets)
+	require.NotNil(t, f)
+	assert.False(t, math.IsNaN(f.Value) || math.IsInf(f.Value, 0))
+}
+
+func TestFromDepth_CrossedConsolidatedTouchIsUnpriced(t *testing.T) {
+	// YES bid 61.5 vs NO bid 45 -> consolidated ask 55 < bid 61.5: the arbitrage
+	// state. Must be quarantined, not averaged.
+	buckets := buildDepth(cents(62.5, 31.25, 6.25), nil, threeBounds)
+	crossed := BucketDepth{
+		Lower: nil, Upper: Ptr(1.0),
+		YesBids: []BookLevel{{Price: 61.5, Size: 100}},
+		NoBids:  []BookLevel{{Price: 45, Size: 100}}, // -> consolidated ask at 55, crossed
+	}
+	f := FromDepth(append([]BucketDepth{crossed}, buckets[1:]...))
+	require.NotNil(t, f)
+	assert.True(t, hasWarning(f, "crossed"))
+}
+
+func TestFromDepth_MatchesQuotePathOnSymmetricBooks(t *testing.T) {
+	// On a symmetric mirrored book the depth path and the best-quote path must
+	// agree on the probabilities (same mids, same residuals).
+	btcBounds := []bound{
+		{nil, Ptr(65000.0)},
+		{Ptr(65000.0), Ptr(70000.0)},
+		{Ptr(70000.0), nil},
+	}
+	mids := []float64{62.5, 31.25, 6.25}
+
+	depth := buildDepth(cents(62.5, 31.25, 6.25), nil, btcBounds)
+	quotes := make([]BucketBook, len(btcBounds))
+	for i, b := range btcBounds {
+		quotes[i] = BucketBook{
+			Lower: b.lower, Upper: b.upper,
+			BestBid: Ptr(mids[i] - 1), BestAsk: Ptr(mids[i] + 1),
+		}
+	}
+
+	fd, fq := FromDepth(depth), FromBuckets(quotes)
+	require.NotNil(t, fd)
+	require.NotNil(t, fq)
+	for i := range fd.Buckets {
+		assert.InDelta(t, fq.Buckets[i].Probability, fd.Buckets[i].Probability, 1e-9)
+	}
+	assert.InDelta(t, fq.Value, fd.Value, 1e-6)
+}

--- a/core/forecast/forecast_test.go
+++ b/core/forecast/forecast_test.go
@@ -1,0 +1,308 @@
+// Tests for the market-implied point forecast (best-quote path).
+//
+// Ported case-for-case from sdk-py's tests/test_forecast.py, which is itself the
+// upstream prediction-bots suite. Keeping the cases aligned is what proves the
+// SDKs agree: this package is a hand translation, so behaviour is the only thing
+// that can be diffed.
+
+package forecast
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bound is a bucket's [lower, upper) pair, nil meaning open-ended.
+type bound struct {
+	lower *float64
+	upper *float64
+}
+
+// msftBounds is the MSFT EPS 2026 Q3 bucket layout, as configured on mainnet.
+var msftBounds = []bound{
+	{nil, Ptr(4.04)},
+	{Ptr(4.04), Ptr(4.33)},
+	{Ptr(4.33), Ptr(4.62)},
+	{Ptr(4.62), Ptr(4.92)},
+	{Ptr(4.92), nil},
+}
+
+// build returns books quoting each bucket at the given cents, with a symmetric
+// spread. A nil entry leaves the bucket unquoted.
+func build(cents []*float64, bounds []bound, spread float64) []BucketBook {
+	books := make([]BucketBook, len(bounds))
+	for i, b := range bounds {
+		books[i] = BucketBook{Lower: b.lower, Upper: b.upper}
+		if cents[i] != nil {
+			books[i].BestBid = Ptr(math.Max(1, *cents[i]-spread/2))
+			books[i].BestAsk = Ptr(math.Min(99, *cents[i]+spread/2))
+		}
+	}
+	return books
+}
+
+// cents is shorthand for a quote list; nil entries stay unquoted.
+func cents(values ...interface{}) []*float64 {
+	out := make([]*float64, len(values))
+	for i, v := range values {
+		switch n := v.(type) {
+		case int:
+			out[i] = Ptr(float64(n))
+		case float64:
+			out[i] = Ptr(n)
+		case nil:
+			out[i] = nil
+		}
+	}
+	return out
+}
+
+// msft builds the standard MSFT-shaped book at a 2c spread.
+func msft(values ...interface{}) []BucketBook {
+	return build(cents(values...), msftBounds, 2)
+}
+
+// mustForecast asserts a forecast was produced and returns it.
+func mustForecast(t *testing.T, books []BucketBook) *MarketForecast {
+	t.Helper()
+	f := FromBuckets(books)
+	require.NotNil(t, f)
+	return f
+}
+
+func hasWarning(f *MarketForecast, substring string) bool {
+	for _, w := range f.Warnings {
+		if strings.Contains(w, substring) {
+			return true
+		}
+	}
+	return false
+}
+
+// ═══════════════════════════════════════════════════════════════
+// BRACKET LOGIC
+// ═══════════════════════════════════════════════════════════════
+
+func TestBucketProbability_TwoSidedQuoteIsTheMidpoint(t *testing.T) {
+	p, conf, oneSided, quoted := BucketProbability(Ptr(38.0), Ptr(42.0), DefaultHalfSpread)
+	require.NotNil(t, p)
+	assert.InDelta(t, 0.40, *p, 1e-12)
+	assert.InDelta(t, 0.96, conf, 1e-12)
+	assert.False(t, oneSided)
+	assert.True(t, quoted)
+}
+
+func TestBucketProbability_TighterSpreadMeansMoreConfidence(t *testing.T) {
+	_, tight, _, _ := BucketProbability(Ptr(39.0), Ptr(41.0), DefaultHalfSpread)
+	_, wide, _, _ := BucketProbability(Ptr(20.0), Ptr(60.0), DefaultHalfSpread)
+	assert.Greater(t, tight, wide)
+}
+
+func TestBucketProbability_OneSidedBookStepsAcrossByTheHalfSpread(t *testing.T) {
+	// A lone bid is real information, but it is a BID: the fair value sits a
+	// half-spread above it, not at the midpoint of [bid, 1].
+	p, conf, oneSided, quoted := BucketProbability(Ptr(30.0), nil, 0.06)
+	require.NotNil(t, p)
+	assert.True(t, oneSided)
+	assert.True(t, quoted)
+	assert.InDelta(t, 0.36, *p, 1e-12)
+	assert.Less(t, conf, 0.75, "we inferred one side rather than observing it")
+}
+
+func TestBucketProbability_LonePennyBidIsNotACoinFlip(t *testing.T) {
+	// The bug live books exposed: the [0.01, 1.0] midpoint made dead tails 50%.
+	p, _, _, _ := BucketProbability(Ptr(1.0), nil, 0.06)
+	require.NotNil(t, p)
+	assert.InDelta(t, 0.07, *p, 1e-12)
+	assert.Less(t, *p, 0.15)
+}
+
+func TestBucketProbability_EmptyBookReturnsNilNotANumber(t *testing.T) {
+	p, conf, oneSided, quoted := BucketProbability(nil, nil, DefaultHalfSpread)
+	assert.Nil(t, p)
+	assert.Zero(t, conf)
+	assert.False(t, quoted)
+	assert.False(t, oneSided)
+}
+
+func TestBucketProbability_CrossedBookIsDistrusted(t *testing.T) {
+	_, conf, _, _ := BucketProbability(Ptr(60.0), Ptr(40.0), DefaultHalfSpread)
+	assert.LessOrEqual(t, conf, 1e-3)
+}
+
+// ═══════════════════════════════════════════════════════════════
+// THE CORE ESTIMATE
+// ═══════════════════════════════════════════════════════════════
+
+func TestFromBuckets_SymmetricMarketCentresOnTheMiddleBucket(t *testing.T) {
+	// Mass symmetric about bucket 3 must imply its midpoint, (4.33+4.62)/2.
+	f := mustForecast(t, msft(5, 20, 50, 20, 5))
+	assert.Equal(t, MethodRank, f.Method)
+	assert.InDelta(t, 4.475, f.Value, 0.03)
+	assert.Equal(t, BasisInterior, f.ValueBasis)
+}
+
+func TestFromBuckets_MovesWithTheMass(t *testing.T) {
+	low := mustForecast(t, msft(40, 30, 20, 7, 3)).Value
+	mid := mustForecast(t, msft(5, 20, 50, 20, 5)).Value
+	high := mustForecast(t, msft(3, 7, 20, 30, 40)).Value
+	assert.Less(t, low, mid)
+	assert.Less(t, mid, high)
+}
+
+func TestFromBuckets_LandsInsideTheLeadingBucket(t *testing.T) {
+	f := mustForecast(t, msft(5, 10, 60, 20, 5))
+	assert.GreaterOrEqual(t, f.Value, 4.33)
+	assert.LessOrEqual(t, f.Value, 4.62)
+}
+
+func TestFromBuckets_OpenTailsNeedNoAssumedValue(t *testing.T) {
+	// Heavy mass in the unbounded top bucket must still give a finite answer
+	// that sits above the last boundary.
+	f := mustForecast(t, msft(1, 2, 7, 20, 70))
+	assert.False(t, math.IsInf(f.Value, 0) || math.IsNaN(f.Value))
+	assert.Greater(t, f.Value, 4.92)
+}
+
+func TestFromBuckets_ProbabilitiesAreNormalised(t *testing.T) {
+	f := mustForecast(t, msft(10, 25, 55, 25, 10)) // sums to 125c
+	var total float64
+	for _, b := range f.Buckets {
+		total += b.Probability
+	}
+	assert.InDelta(t, 1.0, total, 1e-12)
+	assert.True(t, hasWarning(f, "sum to"))
+}
+
+// ═══════════════════════════════════════════════════════════════
+// THE TWO UNCERTAINTIES
+// ═══════════════════════════════════════════════════════════════
+
+func TestFromBuckets_BandIsThePublishedUncertainty(t *testing.T) {
+	// Under the rank method the band IS the uncertainty statement: the market
+	// says the outcome lands in [p10, p90] with 80% probability. Margin and
+	// sigma are derived from it for compatibility.
+	f := mustForecast(t, msft(5, 20, 50, 20, 5))
+	require.NotNil(t, f.P10)
+	require.NotNil(t, f.P90)
+	assert.Less(t, *f.P10, f.Value)
+	assert.Less(t, f.Value, *f.P90)
+	assert.InDelta(t, (*f.P90-*f.P10)/2, f.MarginOfError, 1e-12)
+	assert.InDelta(t, (*f.P90-*f.P10)/2.5631, f.Sigma, 1e-12)
+}
+
+func TestFromBuckets_TightBooksPinTheValueBetterThanWideOnes(t *testing.T) {
+	tight := mustForecast(t, build(cents(5, 20, 50, 20, 5), msftBounds, 2))
+	wide := mustForecast(t, build(cents(5, 20, 50, 20, 5), msftBounds, 30))
+	assert.Greater(t, wide.MarginOfError, tight.MarginOfError)
+}
+
+func TestFromBuckets_OneSidedBooksWidenTheMargin(t *testing.T) {
+	twoSided := mustForecast(t, msft(5, 20, 50, 20, 5))
+
+	quotes := []float64{5, 20, 50, 20, 5}
+	half := make([]BucketBook, len(msftBounds))
+	for i, b := range msftBounds {
+		half[i] = BucketBook{Lower: b.lower, Upper: b.upper, BestBid: Ptr(quotes[i])}
+	}
+	oneSided := mustForecast(t, half)
+
+	assert.Greater(t, oneSided.MarginOfError, twoSided.MarginOfError)
+	assert.True(t, hasWarning(oneSided, "one-sided"))
+}
+
+func TestFromBuckets_LowHighBracketTheValue(t *testing.T) {
+	f := mustForecast(t, msft(5, 20, 50, 20, 5))
+	assert.Less(t, f.Low(), f.Value)
+	assert.Less(t, f.Value, f.High())
+	assert.InDelta(t, 2*f.MarginOfError, f.High()-f.Low(), 1e-12)
+}
+
+// ═══════════════════════════════════════════════════════════════
+// DEGENERATE INPUT
+// ═══════════════════════════════════════════════════════════════
+
+func TestFromBuckets_NoQuotesAtAllReturnsNil(t *testing.T) {
+	assert.Nil(t, FromBuckets(msft(nil, nil, nil, nil, nil)))
+}
+
+func TestFromBuckets_TooFewBucketsReturnsNil(t *testing.T) {
+	assert.Nil(t, FromBuckets([]BucketBook{
+		{Lower: nil, Upper: Ptr(4.0), BestBid: Ptr(40.0), BestAsk: Ptr(44.0)},
+	}))
+}
+
+func TestFromBuckets_PartialBookStillProducesAnEstimate(t *testing.T) {
+	f := mustForecast(t, msft(nil, 20, 50, 20, nil))
+	assert.False(t, math.IsNaN(f.Value))
+	assert.True(t, hasWarning(f, "unquoted"))
+}
+
+func TestFromBuckets_UnquotedBucketsTakeTheResidualNotAFlatHalf(t *testing.T) {
+	// Quoted buckets sum to ~0.9, so the two unquoted ones share ~0.1 between
+	// them, rather than being handed 0.5 each and swamping the distribution.
+	f := mustForecast(t, msft(nil, 20, 50, 20, nil))
+	assert.InDelta(t, f.Buckets[4].Probability, f.Buckets[0].Probability, 1e-12)
+	assert.Less(t, f.Buckets[0].Probability, 0.10, "unquoted tail took too much")
+	assert.Greater(t, f.Buckets[2].Probability, 0.4, "the quoted leading bucket must still dominate")
+}
+
+func TestFromBuckets_DeadTailsDoNotDominateALiveMiddle(t *testing.T) {
+	// Reproduces the live MSFT book: penny-bid one-sided tails around a tight
+	// two-sided middle. The tails must not come out level with the leader.
+	f := mustForecast(t, []BucketBook{
+		{Lower: nil, Upper: Ptr(4.04), BestBid: Ptr(1.0)},
+		{Lower: Ptr(4.04), Upper: Ptr(4.33), BestBid: Ptr(16.0), BestAsk: Ptr(28.0)},
+		{Lower: Ptr(4.33), Upper: Ptr(4.62), BestBid: Ptr(44.0), BestAsk: Ptr(56.0)},
+		{Lower: Ptr(4.62), Upper: Ptr(4.92), BestBid: Ptr(9.0), BestAsk: Ptr(21.0)},
+		{Lower: Ptr(4.92), Upper: nil, BestBid: Ptr(1.0)},
+	})
+
+	top := 0.0
+	for _, b := range f.Buckets {
+		top = math.Max(top, b.Probability)
+	}
+	assert.Equal(t, top, f.Buckets[2].Probability, "the tight 44-56 bucket must lead")
+	assert.Less(t, f.Buckets[0].Probability, 0.15)
+	assert.Less(t, f.Buckets[4].Probability, 0.15)
+	assert.GreaterOrEqual(t, f.Value, 4.2)
+	assert.LessOrEqual(t, f.Value, 4.7)
+}
+
+func TestFromBuckets_AllMassInOneBucketDoesNotExplode(t *testing.T) {
+	f := mustForecast(t, msft(1, 1, 95, 1, 1))
+	assert.False(t, math.IsNaN(f.Value) || math.IsInf(f.Value, 0))
+	assert.False(t, math.IsNaN(f.MarginOfError) || math.IsInf(f.MarginOfError, 0))
+	assert.GreaterOrEqual(t, f.Value, 4.0)
+	assert.LessOrEqual(t, f.Value, 5.0)
+}
+
+func TestFromBuckets_FlatBookFallsBackRatherThanDividingByZero(t *testing.T) {
+	// Identical quotes everywhere say nothing about spread.
+	f := mustForecast(t, msft(20, 20, 20, 20, 20))
+	assert.False(t, math.IsNaN(f.Value) || math.IsInf(f.Value, 0))
+}
+
+func TestFromBuckets_AsMapIsSerialisable(t *testing.T) {
+	m := mustForecast(t, msft(5, 20, 50, 20, 5)).AsMap()
+	for _, key := range []string{"value", "margin_of_error", "low", "high", "sigma", "method"} {
+		assert.Contains(t, m, key)
+	}
+	assert.Len(t, m["probabilities"], 5)
+
+	encoded, err := json.Marshal(m)
+	require.NoError(t, err)
+	assert.NotEmpty(t, encoded)
+}
+
+func TestFromBuckets_MonotonicCDFIsEnforced(t *testing.T) {
+	// Noisy quotes can imply a tiny negative probability step; the CDF walk must
+	// not trip over it.
+	f := mustForecast(t, msft(30, 1, 40, 1, 28))
+	assert.False(t, math.IsNaN(f.Value) || math.IsInf(f.Value, 0))
+}

--- a/core/forecast/forecast_test.go
+++ b/core/forecast/forecast_test.go
@@ -300,6 +300,66 @@ func TestFromBuckets_AsMapIsSerialisable(t *testing.T) {
 	assert.NotEmpty(t, encoded)
 }
 
+func TestFromBuckets_DustQuoteIsTreatedAsAbsent(t *testing.T) {
+	// A quote below MinQuoteNotionalCentShares is too small to mean anything:
+	// one 90c bid on a dead tail moved the old estimator by 8 units for 90c of
+	// risk. Supplying the sizes turns the floor on.
+	dusted := BucketBook{
+		Lower: Ptr(4.33), Upper: Ptr(4.62),
+		BestBid: Ptr(44.0), BestAsk: Ptr(56.0),
+		BidSize: Ptr(1.0), AskSize: Ptr(1.0), // 44 and 56 cent-shares, under 100
+	}
+	assert.Nil(t, dusted.UsableBid())
+	assert.Nil(t, dusted.UsableAsk())
+
+	funded := dusted
+	funded.BidSize, funded.AskSize = Ptr(100.0), Ptr(100.0)
+	require.NotNil(t, funded.UsableBid())
+	require.NotNil(t, funded.UsableAsk())
+
+	// Unset sizes mean "no floor", which is how the quote-only path behaves.
+	unsized := BucketBook{Lower: Ptr(4.33), Upper: Ptr(4.62), BestBid: Ptr(44.0)}
+	require.NotNil(t, unsized.UsableBid())
+}
+
+func TestFromBuckets_DustedBucketTakesTheResidual(t *testing.T) {
+	// Filtered out at the top of book, the bucket must read as unquoted rather
+	// than as a bucket priced at the dust.
+	books := msft(5, 20, 50, 20, 5)
+	books[4].BidSize, books[4].AskSize = Ptr(1.0), Ptr(1.0)
+
+	f := mustForecast(t, books)
+	assert.True(t, hasWarning(f, "unquoted"))
+	assert.False(t, f.Buckets[4].Quoted)
+}
+
+func TestFromBuckets_DutchBookOnTheAsksIsReported(t *testing.T) {
+	// Buying YES in every bucket settles at exactly 1, so asks summing to less
+	// is risk-free money against us.
+	f := mustForecast(t, []BucketBook{
+		{Lower: nil, Upper: Ptr(4.04), BestBid: Ptr(1.0), BestAsk: Ptr(2.0)},
+		{Lower: Ptr(4.04), Upper: Ptr(4.33), BestBid: Ptr(5.0), BestAsk: Ptr(6.0)},
+		{Lower: Ptr(4.33), Upper: Ptr(4.62), BestBid: Ptr(10.0), BestAsk: Ptr(11.0)},
+		{Lower: Ptr(4.62), Upper: Ptr(4.92), BestBid: Ptr(5.0), BestAsk: Ptr(6.0)},
+		{Lower: Ptr(4.92), Upper: nil, BestBid: Ptr(1.0), BestAsk: Ptr(2.0)},
+	})
+	assert.True(t, hasWarning(f, "DUTCH BOOK: asks sum to"))
+	assert.True(t, hasWarning(f, "risk-free"))
+}
+
+func TestFromBuckets_DutchBookOnTheBidsIsReported(t *testing.T) {
+	// Minting a pair in every bucket and selling the YES also settles at 1, so
+	// bids summing to more is the mirror case.
+	f := mustForecast(t, []BucketBook{
+		{Lower: nil, Upper: Ptr(4.04), BestBid: Ptr(30.0), BestAsk: Ptr(90.0)},
+		{Lower: Ptr(4.04), Upper: Ptr(4.33), BestBid: Ptr(30.0), BestAsk: Ptr(90.0)},
+		{Lower: Ptr(4.33), Upper: Ptr(4.62), BestBid: Ptr(30.0), BestAsk: Ptr(90.0)},
+		{Lower: Ptr(4.62), Upper: Ptr(4.92), BestBid: Ptr(30.0), BestAsk: Ptr(90.0)},
+		{Lower: Ptr(4.92), Upper: nil, BestBid: Ptr(30.0), BestAsk: Ptr(90.0)},
+	})
+	assert.True(t, hasWarning(f, "DUTCH BOOK: bids sum to"))
+}
+
 func TestFromBuckets_MonotonicCDFIsEnforced(t *testing.T) {
 	// Noisy quotes can imply a tiny negative probability step; the CDF walk must
 	// not trip over it.

--- a/core/types/order_book_types.go
+++ b/core/types/order_book_types.go
@@ -8,6 +8,7 @@ import (
 
 	kwiltypes "github.com/trufnetwork/kwil-db/core/types"
 	kwilClientType "github.com/trufnetwork/kwil-db/core/client/types"
+	"github.com/trufnetwork/sdk-go/core/forecast"
 )
 
 // ═══════════════════════════════════════════════════════════════
@@ -114,6 +115,17 @@ type IOrderBook interface {
 	// Maps to: get_best_prices($query_id, $outcome)
 	// Migration: 038-order-book-queries.sql:219-268
 	GetBestPrices(ctx context.Context, input GetBestPricesInput) (*BestPrices, error)
+
+	// GetMarketForecast collapses a market's bucket books into the single value
+	// they imply: the median of the implied distribution, plus the band around it.
+	//
+	// Composed of get_market_info and get_order_book calls rather than mapping to
+	// one action. Both the YES and NO books are read, because on this venue a
+	// resting BUY NO at p is hittable by a BUY YES at 100-p (mint match), so NO
+	// liquidity is executable YES liquidity.
+	//
+	// Returns a nil forecast, and no error, when no bucket has a usable quote.
+	GetMarketForecast(ctx context.Context, input GetMarketForecastInput) (*forecast.MarketForecast, error)
 
 	// GetUserCollateral returns caller's total locked collateral value
 	// Maps to: get_user_collateral()
@@ -506,6 +518,27 @@ type GetBestPricesInput struct {
 func (g *GetBestPricesInput) Validate() error {
 	if g.QueryID < 1 {
 		return fmt.Errorf("query_id must be positive, got %d", g.QueryID)
+	}
+	return nil
+}
+
+// GetMarketForecastInput contains parameters for forecasting a market
+type GetMarketForecastInput struct {
+	// QueryIDs are the bucket market IDs of ONE market. Order does not matter;
+	// they are sorted by bound internally.
+	QueryIDs []int
+}
+
+// Validate checks if GetMarketForecastInput is valid
+func (g *GetMarketForecastInput) Validate() error {
+	if len(g.QueryIDs) < 2 {
+		return fmt.Errorf(
+			"a market forecast needs at least 2 bucket query_ids, got %d", len(g.QueryIDs))
+	}
+	for _, queryID := range g.QueryIDs {
+		if queryID < 1 {
+			return fmt.Errorf("query_id must be positive, got %d", queryID)
+		}
 	}
 	return nil
 }

--- a/core/types/order_book_types.go
+++ b/core/types/order_book_types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"time"
 
 	kwiltypes "github.com/trufnetwork/kwil-db/core/types"
@@ -535,10 +536,24 @@ func (g *GetMarketForecastInput) Validate() error {
 		return fmt.Errorf(
 			"a market forecast needs at least 2 bucket query_ids, got %d", len(g.QueryIDs))
 	}
+	counts := make(map[int]int, len(g.QueryIDs))
 	for _, queryID := range g.QueryIDs {
 		if queryID < 1 {
 			return fmt.Errorf("query_id must be positive, got %d", queryID)
 		}
+		counts[queryID]++
+	}
+	var repeated []int
+	for queryID, n := range counts {
+		if n > 1 {
+			repeated = append(repeated, queryID)
+		}
+	}
+	if len(repeated) > 0 {
+		sort.Ints(repeated)
+		return fmt.Errorf(
+			"duplicate bucket query_ids %v; a repeated bucket would have its "+
+				"probability counted twice", repeated)
 	}
 	return nil
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1945,8 +1945,15 @@ func (o *OrderBook) GetMarketForecast(ctx context.Context, input types.GetMarket
 **Returns:**
 - `*forecast.MarketForecast`: the forecast, or `nil` (with a `nil` error) when
   no bucket has a usable quote.
-- `error`: if fewer than two query IDs are given, or a market is missing the
+- `error`: if fewer than two query IDs are given, if any is repeated, if they do
+  not all belong to the same market, or if a market is missing the
   `QueryComponents` needed to derive its bounds.
+
+One forecast covers the buckets of **one** market. A repeated query ID would
+have its bucket counted twice, and mixing two markets would normalise unrelated
+probabilities into a single distribution — both are rejected rather than
+warned about. Buckets of one market differ only in their strike, so the identity
+compared is `(data_provider, stream_id, settle_time)`.
 
 **Cost:** two order-book reads plus one market-info read per bucket. Both the
 YES and NO books are fetched, because on this venue a resting BUY NO at *p* is

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1903,6 +1903,8 @@ type MarketData struct {
     ActionID     string   `json:"action_id"`
     Type         string   `json:"type"`       // "above", "below", "between", "equals" or "unknown"
     Thresholds   []string `json:"thresholds"` // Formatted numeric values as strings
+    Timestamp    *int64   `json:"timestamp"`  // Query observation time, unix seconds
+    FrozenAt     *int64   `json:"frozen_at"`  // Pinned block height; nil means latest
 }
 ```
 
@@ -1953,7 +1955,9 @@ One forecast covers the buckets of **one** market. A repeated query ID would
 have its bucket counted twice, and mixing two markets would normalise unrelated
 probabilities into a single distribution — both are rejected rather than
 warned about. Buckets of one market differ only in their strike, so the identity
-compared is `(data_provider, stream_id, settle_time)`.
+compared is `(data_provider, stream_id, settle_time, timestamp, frozen_at)` —
+the query's own time is included because two markets can settle at the same
+moment while observing the stream at different points.
 
 **Cost:** two order-book reads plus one market-info read per bucket. Both the
 YES and NO books are fetched, because on this venue a resting BUY NO at *p* is

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1908,6 +1908,217 @@ type MarketData struct {
 
 ---
 
+## Market Forecasting
+
+Prediction markets price **ranges**, not values. A five-bucket EPS market says
+"34% chance EPS lands between $2.06 and $2.21"; it never says "EPS will be
+$2.14". The `core/forecast` package inverts that, collapsing the order books
+across every bucket of one market into the single number they collectively
+imply.
+
+```
+market says                     ->  forecast says
+"34% between 2.06 and 2.21"         "2.14, p10..p90 1.91..2.38"
+```
+
+This is the same algorithm as `sdk-py` and `sdk-js`, verified to produce the
+same numbers.
+
+### Core Methods
+
+#### `OrderBook.GetMarketForecast`
+
+Collapses a market's bucket books into the single value they imply.
+
+**Signature:**
+```go
+func (o *OrderBook) GetMarketForecast(ctx context.Context, input types.GetMarketForecastInput) (
+    *forecast.MarketForecast, error,
+)
+```
+
+**Parameters:**
+- `input.QueryIDs` ([]int): The bucket market IDs of **one** market. Order does
+  not matter; they are sorted by bound internally. See *Finding a market's
+  query IDs* below.
+
+**Returns:**
+- `*forecast.MarketForecast`: the forecast, or `nil` (with a `nil` error) when
+  no bucket has a usable quote.
+- `error`: if fewer than two query IDs are given, or a market is missing the
+  `QueryComponents` needed to derive its bounds.
+
+**Cost:** two order-book reads plus one market-info read per bucket. Both the
+YES and NO books are fetched, because on this venue a resting BUY NO at *p* is
+hittable by a BUY YES at *100-p* (mint match), so NO liquidity is executable
+YES liquidity and ignoring it would discard real quotes.
+
+**Example:**
+```go
+import (
+    "github.com/trufnetwork/sdk-go/core/forecast"
+    "github.com/trufnetwork/sdk-go/core/types"
+)
+
+orderBook, err := client.LoadOrderBook()
+if err != nil {
+    log.Fatal(err)
+}
+
+f, err := orderBook.GetMarketForecast(ctx, types.GetMarketForecastInput{
+    QueryIDs: []int{419, 420, 421, 422, 423},
+})
+if err != nil {
+    log.Fatal(err)
+}
+if f == nil {
+    log.Println("no bucket of this market carries a usable quote")
+    return
+}
+
+fmt.Printf("%.4f\n", f.Value)               // 2.1361
+fmt.Printf("%.4f..%.4f\n", *f.P10, *f.P90)  // 1.9055..2.3789
+
+for _, b := range f.Buckets {
+    fmt.Printf("  %.1f%%\n", b.Probability*100)
+}
+for _, w := range f.Warnings {
+    fmt.Printf("  ! %s\n", w)
+}
+```
+
+#### `BucketBoundsFromMarketData`
+
+Converts decoded market data into the bucket's half-open `[lower, upper)`
+bounds. A `nil` bound means open-ended, which is how the outer two buckets are
+always struck. Handles the `below`, `above`, `between` and `equals` market
+types.
+
+**Signature:**
+```go
+func BucketBoundsFromMarketData(market *MarketData) (lower, upper *float64, err error)
+```
+
+### Types
+
+#### `forecast.MarketForecast`
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `Value` | `float64` | The point estimate: the **median** of the implied distribution |
+| `P10`, `P90` | `*float64` | The published band. The market implies an 80% chance the outcome lands inside it |
+| `MarginOfError` | `float64` | Half the P10..P90 band. **Not** a standard error — see below |
+| `Sigma` | `float64` | The band scaled to a normal-equivalent standard deviation |
+| `ValueBasis` | `string` | `BasisInterior`, `BasisTail`, or `BasisUnresolved` — see below |
+| `P10Basis`, `P90Basis` | `string` | Same flags, for each end of the band |
+| `Method` | `string` | `MethodRank` normally, `MethodDiscrete` on a degenerate book |
+| `Buckets` | `[]BucketEstimate` | Per-bucket detail |
+| `Warnings` | `[]string` | Book-quality problems worth surfacing |
+| `Multimodal`, `NPeaks` | `bool`, `int` | Whether the book implies more than one peak |
+| `Low()`, `High()` | `float64` | `Value -/+ MarginOfError` |
+| `AsMap()` | `map[string]any` | Flat, JSON-serialisable form |
+
+Each `BucketEstimate` carries `QueryID`, `Lower`, `Upper`, `Probability`
+(normalised, sums to 1), `RawProbability`, `Confidence`, `OneSided` and
+`Quoted`.
+
+**`MarginOfError` is a band, not a precision.** It is half the P10..P90 spread,
+so it describes how uncertain the **outcome** is, not how tightly the book pins
+your estimate. Expect it to be large — on a live five-bucket EPS market, roughly
+0.24 against a value of 2.14. Publishing it as "± 0.24" is correct; reading it
+as "our estimate is accurate to 0.24" is not.
+
+**Check the basis flags before displaying a number.** The outer two buckets are
+open-ended, so the books say nothing about how far out they extend. When a
+percentile falls inside one, an exponential tail model supplies the number and
+the corresponding flag reads `BasisTail`. `BasisInterior` means it was read
+between real strikes with no shape assumption. `BasisUnresolved` means the
+market has too few strikes to place it at all.
+
+**Read `Warnings`.** Unquoted or one-sided buckets, crossed books, and
+dutch-book deviations are reported rather than silently smoothed over.
+
+### Finding a market's query IDs
+
+Each bucket is a **separate market** with its own query ID, so a "market" is a
+set of them. They can be reassembled from chain data alone: buckets of the same
+market share a data stream and a settlement time.
+
+```go
+active := false // false = active only, per 032-order-book-actions.sql
+limit := 100
+markets, err := orderBook.ListMarkets(ctx, types.ListMarketsInput{
+    SettledFilter: &active, Limit: &limit,
+})
+if err != nil {
+    log.Fatal(err)
+}
+
+groups := map[string][]int{}
+for _, summary := range markets {
+    info, err := orderBook.GetMarketInfo(ctx, types.GetMarketInfoInput{QueryID: summary.ID})
+    if err != nil || len(info.QueryComponents) == 0 {
+        continue
+    }
+    data, err := contractsapi.DecodeMarketData(info.QueryComponents)
+    if err != nil {
+        continue
+    }
+    key := fmt.Sprintf("%s@%d", data.StreamID, summary.SettleTime)
+    groups[key] = append(groups[key], summary.ID)
+}
+
+// A complete market tiles the line: one "below" bucket, one "above", ranges between.
+for _, queryIDs := range groups {
+    f, err := orderBook.GetMarketForecast(ctx, types.GetMarketForecastInput{QueryIDs: queryIDs})
+    _, _ = f, err
+}
+```
+
+A layout that does not tile the line is still estimated, with the problem
+reported in `Warnings` rather than returned as an error.
+
+### Forecasting from your own book data
+
+If you already hold the books, the algorithm is available as pure functions with
+no I/O. `forecast.FromDepth` is the preferred entry point; it consolidates the
+YES and NO ladders itself.
+
+```go
+import "github.com/trufnetwork/sdk-go/core/forecast"
+
+// Full ladders. Prices are positive 1-99 cents on every side.
+// forecast.Ptr saves a temporary for the optional bounds and quotes.
+buckets := []forecast.BucketDepth{
+    {
+        Lower:   nil,                 // nil = open-ended outer bucket
+        Upper:   forecast.Ptr(1.91),
+        YesBids: []forecast.BookLevel{{Price: 4, Size: 386}},
+        NoBids:  []forecast.BookLevel{{Price: 83, Size: 25}},
+        NoAsks:  []forecast.BookLevel{{Price: 97, Size: 6}},
+        QueryID: forecast.Ptr(419),
+    },
+    // ... remaining buckets, ascending
+}
+f := forecast.FromDepth(buckets)
+
+// Or, if you only have top-of-book (no consolidation, weaker estimate):
+f = forecast.FromBuckets([]forecast.BucketBook{
+    {
+        Lower: nil, Upper: forecast.Ptr(1.91),
+        BestBid: forecast.Ptr(4.0), BestAsk: forecast.Ptr(17.0),
+        QueryID: forecast.Ptr(419),
+    },
+    // ...
+})
+```
+
+Buckets must span the whole line, with the first open below (`Lower: nil`) and
+the last open above (`Upper: nil`). Both entry points return `nil` when the
+books carry no usable information at all.
+
+---
+
 ## Attestation Actions Interface
 
 ### Overview

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1918,7 +1918,7 @@ $2.14". The `core/forecast` package inverts that, collapsing the order books
 across every bucket of one market into the single number they collectively
 imply.
 
-```
+```text
 market says                     ->  forecast says
 "34% between 2.06 and 2.21"         "2.14, p10..p90 1.91..2.38"
 ```
@@ -1987,8 +1987,14 @@ if f == nil {
     return
 }
 
-fmt.Printf("%.4f\n", f.Value)               // 2.1361
-fmt.Printf("%.4f..%.4f\n", *f.P10, *f.P90)  // 1.9055..2.3789
+fmt.Printf("%.4f\n", f.Value) // 2.1361
+
+// P10/P90 are nil when the market has too few strikes to place them.
+if f.P10 != nil && f.P90 != nil {
+    fmt.Printf("%.4f..%.4f\n", *f.P10, *f.P90) // 1.9055..2.3789
+} else {
+    fmt.Println("band unresolved")
+}
 
 for _, b := range f.Buckets {
     fmt.Printf("  %.1f%%\n", b.Probability*100)
@@ -2079,10 +2085,23 @@ for _, summary := range markets {
     groups[key] = append(groups[key], summary.ID)
 }
 
-// A complete market tiles the line: one "below" bucket, one "above", ranges between.
+// A complete market tiles the line: one "below" bucket, one "above", ranges
+// between. A stream can also carry a market that is not part of a bucket set at
+// all, so skip anything too small to forecast rather than letting it error.
 for _, queryIDs := range groups {
+    if len(queryIDs) < 2 {
+        continue
+    }
     f, err := orderBook.GetMarketForecast(ctx, types.GetMarketForecastInput{QueryIDs: queryIDs})
-    _, _ = f, err
+    if err != nil {
+        log.Printf("skipping market: %v", err)
+        continue
+    }
+    if f == nil {
+        continue // nothing quoted
+    }
+    // An incomplete layout still forecasts; the problem is in f.Warnings.
+    fmt.Printf("%.4f %v\n", f.Value, f.Warnings)
 }
 ```
 

--- a/tests/integration/market_forecast_test.go
+++ b/tests/integration/market_forecast_test.go
@@ -1,0 +1,354 @@
+// Live-network checks that the SDK reads real order books the right way round.
+//
+// Everything else in the forecast suite feeds the algorithm hand-written
+// numbers, which proves the maths but cannot prove the SDK is reading the CHAIN
+// correctly. If the node ever flipped the sign convention on bids, every one of
+// those tests would still pass while the forecast silently inverted. That is the
+// gap this file covers.
+//
+// Gated on an env var rather than the kwiltest build tag, because it wants a
+// network carrying live markets with real orders rather than a fresh local node:
+//
+//	TN_LIVE_ENDPOINT=https://gateway.mainnet.truf.network \
+//	    go test ./tests/integration/ -run TestMarketForecastLive -v
+//
+// All calls are view actions, so the signing key needs no funds and controls
+// nothing.
+//
+// These assert SHAPES, not numbers. Live books move minute to minute, so pinning
+// an expected value would fail by tomorrow. Exact numbers belong in the unit
+// tests under core/forecast. A wrong FORMULA will pass here quite happily -- this
+// only proves the plumbing between the SDK and the chain is connected the right
+// way round.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kwilcrypto "github.com/trufnetwork/kwil-db/core/crypto"
+	"github.com/trufnetwork/kwil-db/core/crypto/auth"
+	"github.com/trufnetwork/sdk-go/core/contractsapi"
+	"github.com/trufnetwork/sdk-go/core/forecast"
+	"github.com/trufnetwork/sdk-go/core/tnclient"
+	"github.com/trufnetwork/sdk-go/core/types"
+)
+
+const (
+	// maxMarketsScanned bounds discovery, which costs one call per open market.
+	// Mainnet carried ~110 open markets when this was written; the cap is
+	// headroom, not a target.
+	maxMarketsScanned = 500
+
+	// maxGroupsProbed bounds how many candidates are checked for quotes before
+	// giving up. A market can tile the line perfectly and still have nobody
+	// quoting it, which is not a code defect, so candidates are ranked by how
+	// much of the line is actually quoted rather than by bucket count alone --
+	// most open markets carry no orders at all.
+	maxGroupsProbed = 25
+
+	// minQuotedBuckets is the point below which the forecast rests on residuals
+	// more than on orders, which is not what this test is trying to exercise.
+	minQuotedBuckets = 2
+
+	// liveReadOnlyPK signs view actions only. It holds nothing and controls
+	// nothing; declared here so this file stays self-contained.
+	liveReadOnlyPK = "0000000000000000000000000000000000000000000000000000000000000abc"
+)
+
+// liveBucket is one candidate bucket found during discovery.
+type liveBucket struct {
+	queryID int
+	kind    string
+}
+
+// tilesTheLine reports one bucket open below, one open above, at least one in
+// between.
+func tilesTheLine(members []liveBucket) bool {
+	below, above := 0, 0
+	for _, m := range members {
+		switch m.kind {
+		case "below":
+			below++
+		case "above":
+			above++
+		}
+	}
+	return len(members) >= 3 && below == 1 && above == 1
+}
+
+// discoverGroups returns every open market grouped into candidate bucket sets.
+//
+// A market's buckets share a data stream and a settlement time, which is enough
+// to reassemble them from chain data alone -- no local config needed.
+func discoverGroups(ctx context.Context, t *testing.T, ob types.IOrderBook) [][]liveBucket {
+	t.Helper()
+
+	groups := map[string][]liveBucket{}
+	var order []string
+	offset, scanned := 0, 0
+
+	// FALSE means active only, per 032-order-book-actions.sql:358. Settled
+	// markets cannot move and would only waste probes.
+	active := false
+
+	for scanned < maxMarketsScanned {
+		limit := 100
+		page, err := ob.ListMarkets(ctx, types.ListMarketsInput{
+			SettledFilter: &active, Limit: &limit, Offset: &offset,
+		})
+		require.NoError(t, err)
+		if len(page) == 0 {
+			break
+		}
+
+		for _, summary := range page {
+			scanned++
+			info, err := ob.GetMarketInfo(ctx, types.GetMarketInfoInput{QueryID: summary.ID})
+			if err != nil || len(info.QueryComponents) == 0 {
+				continue
+			}
+			market, err := contractsapi.DecodeMarketData(info.QueryComponents)
+			if err != nil {
+				continue
+			}
+			// Legacy or non-bucket markets are not what this test is about.
+			if _, _, err := contractsapi.BucketBoundsFromMarketData(market); err != nil {
+				continue
+			}
+			key := fmt.Sprintf("%s@%d", market.StreamID, summary.SettleTime)
+			if _, seen := groups[key]; !seen {
+				order = append(order, key)
+			}
+			groups[key] = append(groups[key], liveBucket{queryID: summary.ID, kind: market.Type})
+		}
+
+		if len(page) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	var tiling [][]liveBucket
+	for _, key := range order {
+		if tilesTheLine(groups[key]) {
+			tiling = append(tiling, groups[key])
+		}
+	}
+	return tiling
+}
+
+// medianBucket returns the bucket where the implied CDF crosses 50%.
+//
+// NOT the most probable bucket: with probabilities [0.40, 0.35, 0.25] the leader
+// is the first, but the cumulative only reaches half way through the second, so
+// that is where the median belongs.
+func medianBucket(f *forecast.MarketForecast) forecast.BucketEstimate {
+	running := 0.0
+	for _, b := range f.Buckets {
+		running += b.Probability
+		if running >= 0.5 {
+			return b
+		}
+	}
+	return f.Buckets[len(f.Buckets)-1]
+}
+
+func TestMarketForecastLive(t *testing.T) {
+	endpoint := os.Getenv("TN_LIVE_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("live network not configured; set TN_LIVE_ENDPOINT to run")
+	}
+
+	ctx := context.Background()
+
+	key, err := kwilcrypto.Secp256k1PrivateKeyFromHex(liveReadOnlyPK)
+	require.NoError(t, err, "failed to parse the read-only key")
+
+	client, err := tnclient.NewClient(ctx, endpoint, tnclient.WithSigner(auth.GetUserSigner(key)))
+	require.NoError(t, err, "failed to create client")
+
+	ob, err := client.LoadOrderBook()
+	require.NoError(t, err, "failed to load order book")
+
+	candidates := discoverGroups(ctx, t, ob)
+	if len(candidates) == 0 {
+		t.Skip("no open market on this network currently tiles the line")
+	}
+
+	// One cheap call per bucket to find where the orders are. Ranking on this
+	// rather than on bucket count matters: most open markets tile the line
+	// perfectly and carry no orders whatsoever.
+	type ranked struct {
+		quoted   int
+		queryIDs []int
+	}
+	var usable []ranked
+	probed := len(candidates)
+	if probed > maxGroupsProbed {
+		probed = maxGroupsProbed
+	}
+	for _, members := range candidates[:probed] {
+		queryIDs := make([]int, len(members))
+		quoted := 0
+		for i, m := range members {
+			queryIDs[i] = m.queryID
+			best, err := ob.GetBestPrices(ctx, types.GetBestPricesInput{QueryID: m.queryID, Outcome: true})
+			if err == nil && best != nil && (best.BestBid != nil || best.BestAsk != nil) {
+				quoted++
+			}
+		}
+		if quoted >= minQuotedBuckets {
+			usable = append(usable, ranked{quoted: quoted, queryIDs: queryIDs})
+		}
+	}
+	if len(usable) == 0 {
+		t.Skipf("no market among %d tiling candidates had %d+ quoted buckets",
+			probed, minQuotedBuckets)
+	}
+
+	// Most quoted first. Settled markets are already excluded, and on mainnet the
+	// newest markets are routinely the ones with no orders yet, so recency is a
+	// poor signal to rank on.
+	for i := 0; i < len(usable); i++ {
+		for j := i + 1; j < len(usable); j++ {
+			if usable[j].quoted > usable[i].quoted {
+				usable[i], usable[j] = usable[j], usable[i]
+			}
+		}
+	}
+
+	var queryIDs []int
+	var f *forecast.MarketForecast
+	for _, candidate := range usable {
+		result, err := ob.GetMarketForecast(ctx, types.GetMarketForecastInput{QueryIDs: candidate.queryIDs})
+		require.NoError(t, err)
+		if result != nil {
+			queryIDs, f = candidate.queryIDs, result
+			break
+		}
+	}
+	if f == nil {
+		t.Skip("quoted markets found, but none yielded a usable forecast")
+	}
+	t.Logf("forecasting market %v: value=%.4f [%s]", queryIDs, f.Value, f.ValueBasis)
+
+	t.Run("a real market produces a forecast", func(t *testing.T) {
+		assert.GreaterOrEqual(t, len(queryIDs), 3)
+		assert.False(t, f.Value != f.Value, "value is NaN")
+		assert.Contains(t, []string{forecast.MethodRank, forecast.MethodDiscrete}, f.Method)
+		assert.Contains(t,
+			[]string{forecast.BasisInterior, forecast.BasisTail, forecast.BasisUnresolved},
+			f.ValueBasis)
+	})
+
+	t.Run("the probabilities form a distribution", func(t *testing.T) {
+		total := 0.0
+		for _, b := range f.Buckets {
+			assert.GreaterOrEqual(t, b.Probability, 0.0)
+			assert.LessOrEqual(t, b.Probability, 1.0)
+			total += b.Probability
+		}
+		assert.InDelta(t, 1.0, total, 1e-9)
+	})
+
+	t.Run("the value falls in the bucket where the CDF crosses half", func(t *testing.T) {
+		// The point estimate is the median, so it must land in the median
+		// bucket. This is the assertion that would catch a bounds-derivation or
+		// ordering mistake: get the buckets in the wrong order and the value
+		// lands in the wrong one.
+		if f.ValueBasis == forecast.BasisUnresolved {
+			t.Skip("median unresolvable from this market's strikes")
+		}
+		bucket := medianBucket(f)
+		if bucket.Lower != nil {
+			assert.GreaterOrEqual(t, f.Value, *bucket.Lower)
+		}
+		if bucket.Upper != nil {
+			assert.LessOrEqual(t, f.Value, *bucket.Upper)
+		}
+	})
+
+	t.Run("the band brackets the value", func(t *testing.T) {
+		if f.P10 == nil || f.P90 == nil {
+			t.Skip("band unresolvable from this market's strikes")
+		}
+		assert.LessOrEqual(t, *f.P10, f.Value)
+		assert.LessOrEqual(t, f.Value, *f.P90)
+		assert.Greater(t, f.MarginOfError, 0.0)
+	})
+
+	t.Run("the buckets are ordered and tile the line", func(t *testing.T) {
+		// Assembly must hand the algorithm an ascending, gap-free ladder.
+		assert.Nil(t, f.Buckets[0].Lower, "bottom bucket should be open below")
+		assert.Nil(t, f.Buckets[len(f.Buckets)-1].Upper, "top bucket should be open above")
+		for i := 0; i+1 < len(f.Buckets); i++ {
+			upper, lower := f.Buckets[i].Upper, f.Buckets[i+1].Lower
+			require.NotNil(t, upper, "gap between buckets")
+			require.NotNil(t, lower, "gap between buckets")
+			assert.Equal(t, *upper, *lower, "gap or overlap between buckets")
+		}
+	})
+
+	t.Run("the bid sign convention still holds", func(t *testing.T) {
+		// The canary.
+		//
+		// GetOrderBook marks bids with a NEGATIVE price; GetBestPrices reports
+		// the same bid as POSITIVE. Two independent node paths for one fact, so
+		// if either convention ever changes they stop agreeing here -- loudly --
+		// instead of silently inverting every one-sided bucket in the forecast.
+		checked := 0
+		for _, queryID := range queryIDs {
+			for _, outcome := range []bool{true, false} {
+				entries, err := ob.GetOrderBook(ctx, types.GetOrderBookInput{
+					QueryID: queryID, Outcome: outcome,
+				})
+				require.NoError(t, err)
+
+				bestBid, bestAsk := 0, 0
+				for _, e := range entries {
+					if e.Price == 0 {
+						continue // a holding, not a resting order
+					}
+					price := e.Price
+					if price < 0 {
+						price = -price
+					}
+					assert.Greater(t, price, 0)
+					assert.Less(t, price, 100, "outside the 1-99 cent convention")
+					assert.Greater(t, e.Amount, int64(0))
+
+					if e.Price < 0 && -e.Price > bestBid {
+						bestBid = -e.Price
+					}
+					if e.Price > 0 && (bestAsk == 0 || e.Price < bestAsk) {
+						bestAsk = e.Price
+					}
+				}
+
+				best, err := ob.GetBestPrices(ctx, types.GetBestPricesInput{
+					QueryID: queryID, Outcome: outcome,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, best)
+
+				if bestBid > 0 && best.BestBid != nil {
+					assert.Equal(t, *best.BestBid, bestBid, "bid sign convention disagrees")
+					checked++
+				}
+				if bestAsk > 0 && best.BestAsk != nil {
+					assert.Equal(t, *best.BestAsk, bestAsk, "ask convention disagrees")
+					checked++
+				}
+			}
+		}
+		if checked == 0 {
+			t.Skip("no resting orders to cross-check the sign convention against")
+		}
+	})
+}

--- a/tests/integration/market_forecast_test.go
+++ b/tests/integration/market_forecast_test.go
@@ -26,8 +26,11 @@ package integration
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,6 +62,11 @@ const (
 	// liveReadOnlyPK signs view actions only. It holds nothing and controls
 	// nothing; declared here so this file stays self-contained.
 	liveReadOnlyPK = "0000000000000000000000000000000000000000000000000000000000000abc"
+
+	// liveTestTimeout bounds the whole run. Discovery is one call per open
+	// market, so this is generous; it exists to fail on a wedged node rather
+	// than to pace anything.
+	liveTestTimeout = 10 * time.Minute
 )
 
 // liveBucket is one candidate bucket found during discovery.
@@ -165,7 +173,11 @@ func TestMarketForecastLive(t *testing.T) {
 		t.Skip("live network not configured; set TN_LIVE_ENDPOINT to run")
 	}
 
-	ctx := context.Background()
+	// Discovery walks every open market, so the whole sequence gets one bounded
+	// deadline rather than relying on the package test timeout to notice a node
+	// that has stopped answering.
+	ctx, cancel := context.WithTimeout(context.Background(), liveTestTimeout)
+	defer cancel()
 
 	key, err := kwilcrypto.Secp256k1PrivateKeyFromHex(liveReadOnlyPK)
 	require.NoError(t, err, "failed to parse the read-only key")
@@ -215,13 +227,9 @@ func TestMarketForecastLive(t *testing.T) {
 	// Most quoted first. Settled markets are already excluded, and on mainnet the
 	// newest markets are routinely the ones with no orders yet, so recency is a
 	// poor signal to rank on.
-	for i := 0; i < len(usable); i++ {
-		for j := i + 1; j < len(usable); j++ {
-			if usable[j].quoted > usable[i].quoted {
-				usable[i], usable[j] = usable[j], usable[i]
-			}
-		}
-	}
+	sort.SliceStable(usable, func(i, j int) bool {
+		return usable[i].quoted > usable[j].quoted
+	})
 
 	var queryIDs []int
 	var f *forecast.MarketForecast
@@ -240,7 +248,7 @@ func TestMarketForecastLive(t *testing.T) {
 
 	t.Run("a real market produces a forecast", func(t *testing.T) {
 		assert.GreaterOrEqual(t, len(queryIDs), 3)
-		assert.False(t, f.Value != f.Value, "value is NaN")
+		assert.False(t, math.IsNaN(f.Value), "value is NaN")
 		assert.Contains(t, []string{forecast.MethodRank, forecast.MethodDiscrete}, f.Method)
 		assert.Contains(t,
 			[]string{forecast.BasisInterior, forecast.BasisTail, forecast.BasisUnresolved},


### PR DESCRIPTION
## Summary

Ports the market-implied point forecast from `sdk-py` to `sdk-go`, completing the
set: all three SDKs now expose this capability and return the same numbers.

Prediction markets price **ranges**: a five-bucket EPS market says "34% chance
EPS lands between $2.06 and $2.21", never "EPS will be $2.14". This inverts
that, collapsing the order books across every bucket of one market into the
single number they collectively imply, plus the band around it.

```
market says                     ->  forecast says
"34% between 2.06 and 2.21"         "2.14, p10..p90 1.91..2.38"
```

## What's in it

| Purpose | File |
|---|---|
| The algorithm (pure, no I/O, no SDK deps) | `core/forecast/forecast.go` (new package) |
| Bucket bounds from decoded market data | `core/contractsapi/market_buckets.go` |
| `OrderBook.GetMarketForecast` | `core/contractsapi/order_book_forecast.go` |
| Interface method + input type | `core/types/order_book_types.go` |
| Docs | `docs/api-reference.md` |

Three commits, scoped for a clean squash body: `feat:` (algorithm + client +
unit tests), `test:` (live integration suite), `docs:`.

### Mapping to the other SDKs

| sdk-py | sdk-js | sdk-go |
|---|---|---|
| `forecast.py` | `src/util/forecast.ts` | `core/forecast/forecast.go` |
| `market_buckets.py` | `src/util/marketBuckets.ts` | `core/contractsapi/market_buckets.go` |
| `client.get_market_forecast` | `orderbook.getMarketForecast` | `OrderBook.GetMarketForecast` |

Go idioms are used where they beat a literal transcription:

- Optional bounds and quotes are `*float64`, matching the existing
  `BestPrices.BestBid`. `forecast.Ptr` saves a temporary on every literal.
- Python's tuple returns become Go multi-returns — closer to the original than
  the object shape sdk-js had to adopt.
- Python's methods stay methods: `d.ConsolidatedBids()`, `f.Low()`, `f.AsMap()`.
- `GetMarketForecast` follows the repo's input-struct convention
  (`types.GetMarketForecastInput` with `Validate()`) and is added to
  `IOrderBook`.

`core/forecast` imports nothing from the SDK, so the dependency runs one way:
`contractsapi` → `forecast`, `types` → `forecast`. No cycle.

`GetMarketForecast` reads **both** the YES and NO books per bucket. On this venue
a resting BUY NO at *p* is hittable by a BUY YES at *100-p* (mint match), so NO
liquidity is executable YES liquidity — ignoring it would discard real quotes.
That is why the call costs three reads per bucket rather than two.

## Provenance and why this is a translation, not a copy

The algorithm comes from `truflation/prediction-bots` @ `main 21fe4f3` (PR #37),
whose last change to the file was `fafe52b`, by way of the byte-identical mirror
in `sdk-py`.

`sdk-py` can keep a verbatim copy and re-sync with a `diff`. Go cannot, so drift
here has to be caught by **behaviour** instead: `forecast_test.go` and
`forecast_depth_test.go` are ports of the upstream suites, including the frozen
live NVDA book from issue #36. Change the algorithm upstream first, then port it
here and re-run both suites.

## Verification

Passing a ported test suite only proves the tests were ported too, so parity was
checked directly against `sdk-py`.

**Shared case set** — the same 39 cases used to verify the sdk-js port, run
through Go: both paths, open tails, the discrete fallback, dutch books, crossed
touches, dust griefing, the frozen NVDA book. All **2212 leaf values** agree,
warning strings included.

**Live mainnet** — `GetMarketForecast` against the NVDA market (`419-423`), with
the same books replayed through `sdk-py`. `Value`, `P10`, `P90`, `MarginOfError`
and `Sigma` came back **bit-identical** (2.1361, 1.9055..2.3789), and the
warnings matched exactly.

### The residual, stated plainly

~1e-16, worst case 6.5 ULP — the same figure as the sdk-js port, from two causes,
neither a translation error:

1. **CPython 3.12 gave `sum()` compensated (Neumaier) summation** for floats, so
   the Python sums are slightly *more* accurate than the plain left-to-right ones
   here. Reproducing it would mean a compensated adder at every sum site,
   coupling this file to a CPython implementation detail that upstream's source
   does not state — it just says `sum(...)` — and making the translation harder
   to read against the original, which is the whole maintenance strategy.
   `sdk-js` made the same call.

2. **`math.Log` is not bit-identical across runtimes.** This shows up *only* in
   percentiles whose basis is `BasisTail`, the exponential tail model being the
   sole caller of a transcendental. On one case Go's `p90` lands an ULP off
   CPython's and JavaScript's, which agree with each other. Nothing can be done
   about this from inside the algorithm.

Both are fourteen orders of magnitude below the published margin of error.
Documented in the file header so a future re-verification does not read either as
a bug.

## Notes for reviewers

- **No `halfToEven` helper, unlike `sdk-js`.** Go's `fmt` rounds half to even
  natively, which is exactly what Python's format spec does, so the warning
  strings match without intervention. (`toFixed` rounds ties away from zero,
  which is why the TypeScript port needs one.)
- **`_fit_normal` is deliberately not ported.** Upstream still carries the
  weighted-least-squares normal fit on the probit scale that the rank method
  replaced. Nothing calls it — it is unreachable there — so it is not
  translated, which also spares this package an inverse-normal CDF. Noted in the
  header: if it is ever rewired upstream it must be written here from scratch,
  not ported.
- **`GetMarketForecast` is split for testability.** Go cannot stub methods the
  way the TypeScript port does, so the network half is separated from two pure
  functions, `forecastFromBooks` (ordering + layout warnings) and
  `laddersFromEntries` (the bid sign convention). Both are unit-tested offline —
  coverage `sdk-js` only gets from its live run.
- **`MarginOfError` is half the P10..P90 band, not a standard error.** It says
  how uncertain the *outcome* is, not how tightly the book pins the estimate.
  Expect ~0.24 against a value of 2.14 on a live EPS market. Documented, because
  it is the field most likely to be misread downstream.
- **Bucket reads are sequential**, matching `sdk-py` and `sdk-js`. Concurrent
  reads would be faster but fire 3N simultaneous gateway calls; happy to change
  if preferred.

## Testing

- **61 new tests** (42 algorithm, 19 SDK glue). `go build`, `go vet` and `gofmt`
  clean.
- Full suite green except the pre-existing Docker-dependent integration tests,
  which fail locally only because Docker is not installed.
- **6 live subtests pass against mainnet.** Gated on an env var rather than the
  `kwiltest` build tag, because it wants a network carrying live markets with
  real orders rather than a fresh local node:

```bash
TN_LIVE_ENDPOINT=https://gateway.mainnet.truf.network \
    go test ./tests/integration/ -run TestMarketForecastLive -v
```

It skips cleanly when unset, and was run *configured* — a gate that always skips
proves nothing. It independently rediscovered the same NVDA market by grouping
markets on stream and settle time.

The live suite asserts **shapes, not numbers** — live books move minute to
minute, so a pinned value would fail by tomorrow. Exact numbers live in
`core/forecast`. Its job is proving the SDK reads the chain the right way round;
the canary cross-checks `GetOrderBook`'s negative-price bid convention against
`GetBestPrices`' positive one, two independent node paths for one fact.

## Out of scope

While writing the discovery loop I found that **`sdk-js` documents
`ListMarketsInput.settledFilter` backwards** (`true: Unsettled markets only,
false: Settled markets only`). `032-order-book-actions.sql:358` says
`TRUE = settled only, FALSE = active only`, which is what this repo and `sdk-py`
document correctly. Comment only — the value passes straight through, so runtime
behaviour is unaffected. Filed here for visibility; nothing in this PR changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added market forecasting from prediction-market bucket order books.
  * Supports top-of-book and full-depth data, probability estimates, uncertainty ranges, confidence scoring, warnings, and multimodality indicators.
  * Added validation for bucket bounds, query IDs, timestamps, incomplete liquidity, open-ended ranges, and inconsistent market layouts.
  * Market data now includes observation and frozen-at timestamps.

* **Documentation**
  * Added API documentation covering forecast requests, results, metadata, warnings, and forecast construction options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->