### PR TITLE
feat: read consolidated order books from Go

### DIFF
--- a/core/contractsapi/order_book_queries.go
+++ b/core/contractsapi/order_book_queries.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"github.com/trufnetwork/sdk-go/core/forecast"
 	"github.com/trufnetwork/sdk-go/core/types"
 )
 
@@ -125,6 +126,92 @@ func (o *OrderBook) GetBestPrices(ctx context.Context, input types.GetBestPrices
 	}
 
 	return prices, nil
+}
+
+// GetConsolidatedOrderBook returns one outcome's book with the opposite
+// outcome's quotes folded in.
+//
+// Composed of two get_market_depth calls rather than mapping to one action.
+// GetMarketDepth returns a single outcome's ladder, but a binary market's two
+// books are two views of one position and the matching engine fills across them.
+// A resting SELL NO at 93c is a standing offer that lets someone buy YES at 7c,
+// and the chain will execute it. Reading only the YES book makes that quote
+// invisible and the market look thinner than it is.
+//
+// So, in the YES frame:
+//
+//	consolidated bids = YES bids + (100 - p for every NO ask)
+//	consolidated asks = YES asks + (100 - p for every NO bid)
+//
+// The sides swap: a NO ask arrives as a YES bid. Hitting it means both parties
+// sell and the share pair burns; hitting a consolidated ask means both buy and a
+// pair mints.
+//
+// The result is NOT a sweepable ladder. Mint and burn matches fire only when the
+// two prices sum to exactly 100, while a direct same-outcome match crosses. So
+// one order fills every native level past its limit plus exactly ONE inverse
+// level, and walking these levels the way you would walk a regular ladder quotes
+// fills the chain will not produce. Each level keeps Native and Inverse
+// separately so a caller can price that correctly.
+//
+// Input.Outcome frames the prices. The NO-framed book is the YES-framed book
+// reflected, so one call answers either tab.
+func (o *OrderBook) GetConsolidatedOrderBook(
+	ctx context.Context, input types.GetConsolidatedOrderBookInput,
+) (*forecast.ConsolidatedOrderBook, error) {
+	if err := input.Validate(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	native, err := o.GetMarketDepth(ctx, types.GetMarketDepthInput{
+		QueryID: input.QueryID, Outcome: input.Outcome,
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	opposite, err := o.GetMarketDepth(ctx, types.GetMarketDepthInput{
+		QueryID: input.QueryID, Outcome: !input.Outcome,
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	bids := forecast.ConsolidateSide(depthBids(native), depthAsks(opposite), forecast.BidSide)
+	asks := forecast.ConsolidateSide(depthAsks(native), depthBids(opposite), forecast.AskSide)
+
+	return &forecast.ConsolidatedOrderBook{
+		QueryID:   input.QueryID,
+		Outcome:   input.Outcome,
+		Bids:      bids,
+		Asks:      asks,
+		IsCrossed: forecast.Crossed(bids, asks),
+	}, nil
+}
+
+// depthBids returns the buy orders in a depth ladder, as levels.
+func depthBids(depth []types.DepthLevel) []forecast.BookLevel {
+	levels := make([]forecast.BookLevel, 0, len(depth))
+	for _, l := range depth {
+		if l.BuyVolume > 0 {
+			levels = append(levels, forecast.BookLevel{
+				Price: float64(l.Price), Size: float64(l.BuyVolume),
+			})
+		}
+	}
+	return levels
+}
+
+// depthAsks returns the sell orders in a depth ladder, as levels.
+func depthAsks(depth []types.DepthLevel) []forecast.BookLevel {
+	levels := make([]forecast.BookLevel, 0, len(depth))
+	for _, l := range depth {
+		if l.SellVolume > 0 {
+			levels = append(levels, forecast.BookLevel{
+				Price: float64(l.Price), Size: float64(l.SellVolume),
+			})
+		}
+	}
+	return levels
 }
 
 // GetUserCollateral returns caller's total locked collateral value

--- a/core/contractsapi/order_book_queries.go
+++ b/core/contractsapi/order_book_queries.go
@@ -134,9 +134,10 @@ func (o *OrderBook) GetBestPrices(ctx context.Context, input types.GetBestPrices
 // Composed of two get_market_depth calls rather than mapping to one action.
 // GetMarketDepth returns a single outcome's ladder, but a binary market's two
 // books are two views of one position and the matching engine fills across them.
-// A resting SELL NO at 93c is a standing offer that lets someone buy YES at 7c,
-// and the chain will execute it. Reading only the YES book makes that quote
-// invisible and the market look thinner than it is.
+// A resting SELL NO at 93c is a standing BID for YES at 7c: a trader hits it by
+// SELLING YES, both sides sell, and the chain burns the share pair. Reading only
+// the YES book makes that quote invisible and the market look thinner than it
+// is.
 //
 // So, in the YES frame:
 //
@@ -156,6 +157,13 @@ func (o *OrderBook) GetBestPrices(ctx context.Context, input types.GetBestPrices
 //
 // Input.Outcome frames the prices. The NO-framed book is the YES-framed book
 // reflected, so one call answers either tab.
+//
+// The two depth reads are NOT atomic. get_market_depth takes only a query_id and
+// an outcome (038-order-book-queries.sql:182) and the transport exposes no block
+// height, so there is no way to pin both sides to one snapshot from here. On a
+// moving book the two sides can come from adjacent heights, which makes
+// IsCrossed best-effort: re-read before acting on it. Closing the window would
+// take a node action returning both outcomes' depth in one call.
 func (o *OrderBook) GetConsolidatedOrderBook(
 	ctx context.Context, input types.GetConsolidatedOrderBookInput,
 ) (*forecast.ConsolidatedOrderBook, error) {

--- a/core/forecast/consolidated.go
+++ b/core/forecast/consolidated.go
@@ -1,0 +1,143 @@
+package forecast
+
+import "sort"
+
+// Folding a market's two outcome books into the one ladder a trader can hit.
+//
+// A binary market's YES and NO books are two views of one position, and the
+// matching engine treats them that way. A resting SELL NO at p burn-matches an
+// incoming SELL YES at 100-p, and a resting BUY NO at p mint-matches an incoming
+// BUY YES at 100-p. So, in the YES frame:
+//
+//	consolidated bids = YesBids + (100 - p for every NO ask)
+//	consolidated asks = YesAsks + (100 - p for every NO bid)
+//
+// The sides swap. A NO ask is a YES bid, because hitting it means both parties
+// sell and the pair burns. Verified on testnet (2026-08-03).
+//
+// Mint and burn both require the two prices to sum to EXACTLY 100: match_mint
+// and match_burn in the node's 032-order-book-actions.sql return early
+// otherwise, and select the resting order with price = rather than a range. Only
+// a direct same-outcome match crosses prices. That is why every level here
+// carries its native and inverse volume separately instead of only the sum: one
+// order sweeps every native level past its limit but exactly ONE inverse level,
+// so anything quoting a fill needs the split to get the answer right.
+
+// BookSide is which way a consolidated side sorts: bids best-highest, asks
+// best-lowest.
+type BookSide int
+
+const (
+	// BidSide sorts highest price first.
+	BidSide BookSide = iota
+	// AskSide sorts lowest price first.
+	AskSide
+)
+
+// complement is what a YES price and its NO price always sum to.
+const complement = 100
+
+// ConsolidatedLevel is one price level of a consolidated order book, in the
+// requested outcome's frame.
+//
+// Native rests in this outcome's own book and fills as a direct match. Inverse
+// rests in the opposite outcome's book at complement-Price, and fills by minting
+// a share pair on the ask side or burning one on the bid side.
+type ConsolidatedLevel struct {
+	// Price is the level's price in cents, 1-99.
+	Price float64
+	// Total is the shares available here: Native + Inverse.
+	Total float64
+	// Native is the shares resting in this outcome's own book.
+	Native float64
+	// Inverse is the shares resting in the opposite outcome's book at 100-Price.
+	Inverse float64
+}
+
+// ConsolidatedOrderBook is one outcome's order book with the opposite outcome's
+// quotes folded in.
+type ConsolidatedOrderBook struct {
+	// QueryID is the market this book belongs to.
+	QueryID int
+	// Outcome is which side the prices are framed in: true=YES, false=NO.
+	Outcome bool
+	// Bids are the executable bids, best (highest) first.
+	Bids []ConsolidatedLevel
+	// Asks are the executable asks, best (lowest) first.
+	Asks []ConsolidatedLevel
+	// IsCrossed reports whether the best bid sits at or above the best ask.
+	//
+	// A consolidated book can be crossed and stay that way. A YES bid at 61 and
+	// a NO bid at 45 read as a bid at 61 over an ask at 55, and the engine will
+	// never match them because 61 + 45 is not 100. Render it rather than
+	// treating it as bad data.
+	IsCrossed bool
+}
+
+// InversePrice returns the price in the opposite outcome's frame that this price
+// is hittable at.
+func InversePrice(price float64) float64 { return round4(complement - price) }
+
+// ConsolidateSide returns one side of a consolidated ladder: this outcome's own
+// levels plus the opposite outcome's levels inverted into this frame.
+//
+// Pass the opposite side of the opposite book. Consolidated bids take the
+// opposite outcome's asks; consolidated asks take its bids.
+//
+// Levels landing on the same price merge into one entry that keeps the
+// native/inverse split. Zero and negative sizes are dropped.
+func ConsolidateSide(native, opposite []BookLevel, side BookSide) []ConsolidatedLevel {
+	byPrice := make(map[float64]*ConsolidatedLevel, len(native)+len(opposite))
+	order := make([]float64, 0, len(native)+len(opposite))
+
+	add := func(price, size float64, inverse bool) {
+		if size <= 0 {
+			return
+		}
+		level, ok := byPrice[price]
+		if !ok {
+			level = &ConsolidatedLevel{Price: price}
+			byPrice[price] = level
+			order = append(order, price)
+		}
+		if inverse {
+			level.Inverse += size
+		} else {
+			level.Native += size
+		}
+		level.Total += size
+	}
+
+	for _, l := range native {
+		add(l.Price, l.Size, false)
+	}
+	for _, l := range opposite {
+		add(InversePrice(l.Price), l.Size, true)
+	}
+
+	levels := make([]ConsolidatedLevel, 0, len(order))
+	for _, price := range order {
+		levels = append(levels, *byPrice[price])
+	}
+	sort.SliceStable(levels, func(i, j int) bool {
+		if side == BidSide {
+			return levels[i].Price > levels[j].Price
+		}
+		return levels[i].Price < levels[j].Price
+	})
+	return levels
+}
+
+// Crossed reports whether the best bid sits at or above the best ask.
+func Crossed(bids, asks []ConsolidatedLevel) bool {
+	return len(bids) > 0 && len(asks) > 0 && bids[0].Price >= asks[0].Price
+}
+
+// flatten drops the native/inverse split, for callers that only need the ladder.
+func flatten(levels []ConsolidatedLevel) []BookLevel {
+	out := make([]BookLevel, 0, len(levels))
+	for _, l := range levels {
+		out = append(out, BookLevel{Price: l.Price, Size: l.Total})
+	}
+	return out
+}

--- a/core/forecast/consolidated_test.go
+++ b/core/forecast/consolidated_test.go
@@ -1,0 +1,163 @@
+// Tests for folding a market's two outcome books into one executable ladder.
+//
+// What matters here is that the SIDES swap (a NO ask is a YES bid, not a YES
+// ask) and that each level keeps its native/inverse split, since mint and burn
+// only fire at the exact complement and a caller quoting a fill needs to know
+// which volume is which.
+
+package forecast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsolidateSide_NoAskBecomesAYesBid(t *testing.T) {
+	// The case from truflation/website#4385: an ask for 4 shares of NO at 93c is
+	// economically a bid for 4 shares of YES at 7c, and the chain burns the pair
+	// to fill it.
+	bids := ConsolidateSide(nil, []BookLevel{{Price: 93, Size: 4}}, BidSide)
+
+	require.Len(t, bids, 1)
+	assert.Equal(t, ConsolidatedLevel{Price: 7, Total: 4, Native: 0, Inverse: 4}, bids[0])
+}
+
+func TestConsolidateSide_NoBidBecomesAYesAsk(t *testing.T) {
+	asks := ConsolidateSide(nil, []BookLevel{{Price: 41, Size: 200}}, AskSide)
+
+	require.Len(t, asks, 1)
+	assert.Equal(t, ConsolidatedLevel{Price: 59, Total: 200, Native: 0, Inverse: 200}, asks[0])
+}
+
+func TestConsolidateSide_MergesOnePriceAndKeepsTheSplit(t *testing.T) {
+	asks := ConsolidateSide(
+		[]BookLevel{{Price: 59, Size: 100}},
+		[]BookLevel{{Price: 41, Size: 200}},
+		AskSide,
+	)
+
+	require.Len(t, asks, 1)
+	assert.Equal(t, ConsolidatedLevel{Price: 59, Total: 300, Native: 100, Inverse: 200}, asks[0])
+}
+
+func TestConsolidateSide_Sorts(t *testing.T) {
+	asks := ConsolidateSide(
+		[]BookLevel{{Price: 60, Size: 100}},
+		[]BookLevel{{Price: 41, Size: 200}, {Price: 45, Size: 50}},
+		AskSide,
+	)
+	assert.Equal(t, []float64{55, 59, 60}, prices(asks))
+
+	bids := ConsolidateSide(
+		[]BookLevel{{Price: 30, Size: 10}},
+		[]BookLevel{{Price: 55, Size: 25}},
+		BidSide,
+	)
+	assert.Equal(t, []float64{45, 30}, prices(bids))
+}
+
+func TestConsolidateSide_DropsEmptyLevels(t *testing.T) {
+	levels := ConsolidateSide(
+		[]BookLevel{{Price: 45, Size: 0}, {Price: 44, Size: 10}},
+		[]BookLevel{{Price: 20, Size: -5}},
+		BidSide,
+	)
+
+	require.Len(t, levels, 1)
+	assert.Equal(t, float64(44), levels[0].Price)
+}
+
+func TestConsolidateSide_MirrorsBetweenFrames(t *testing.T) {
+	yesBids := []BookLevel{{Price: 30, Size: 10}}
+	yesAsks := []BookLevel{{Price: 60, Size: 100}}
+	noBids := []BookLevel{{Price: 41, Size: 200}}
+	noAsks := []BookLevel{{Price: 55, Size: 25}}
+
+	yesFrame := ConsolidateSide(yesBids, noAsks, BidSide)
+	noFrame := ConsolidateSide(noAsks, yesBids, AskSide)
+
+	// Price q on one side is 100-q on the other, bids become asks, and what was
+	// native in the YES frame is inverse in the NO frame.
+	require.Len(t, noFrame, len(yesFrame))
+	for i, l := range yesFrame {
+		assert.Equal(t, ConsolidatedLevel{
+			Price:   100 - l.Price,
+			Total:   l.Total,
+			Native:  l.Inverse,
+			Inverse: l.Native,
+		}, noFrame[i])
+	}
+
+	// And the same the other way, so the reflection is not an artifact of which
+	// side happened to be listed first.
+	yesAskFrame := ConsolidateSide(yesAsks, noBids, AskSide)
+	noBidFrame := ConsolidateSide(noBids, yesAsks, BidSide)
+	require.Len(t, noBidFrame, len(yesAskFrame))
+	for i, l := range yesAskFrame {
+		assert.Equal(t, 100-l.Price, noBidFrame[i].Price)
+		assert.Equal(t, l.Total, noBidFrame[i].Total)
+	}
+}
+
+func TestConsolidateSide_InvertsFractionalPricesWithoutFloatDust(t *testing.T) {
+	levels := ConsolidateSide(nil, []BookLevel{{Price: 0.1, Size: 1}}, BidSide)
+
+	require.Len(t, levels, 1)
+	assert.Equal(t, 99.9, levels[0].Price)
+}
+
+func TestCrossed(t *testing.T) {
+	// A YES bid at 61 and a NO bid at 45 read as a bid at 61 over an ask at 55.
+	// 61 + 45 is 106, so no mint fires and the crossing rests indefinitely.
+	bids := ConsolidateSide([]BookLevel{{Price: 61, Size: 30}}, nil, BidSide)
+	asks := ConsolidateSide(nil, []BookLevel{{Price: 45, Size: 30}}, AskSide)
+
+	require.Equal(t, float64(61), bids[0].Price)
+	require.Equal(t, float64(55), asks[0].Price)
+	assert.True(t, Crossed(bids, asks))
+
+	assert.False(t, Crossed(bids, nil))
+	assert.False(t, Crossed(nil, asks))
+	assert.False(t, Crossed(
+		ConsolidateSide([]BookLevel{{Price: 45, Size: 10}}, nil, BidSide),
+		ConsolidateSide(nil, []BookLevel{{Price: 44, Size: 20}}, AskSide),
+	))
+}
+
+func TestBucketLaddersMergeWithoutMovingTheForecastInputs(t *testing.T) {
+	// ConsolidatedBids/Asks now merge same-price levels. Everything downstream
+	// sums price x size or walks in price order, so the ladder totals the
+	// forecast reads must be unchanged.
+	depth := BucketDepth{
+		YesBids: []BookLevel{{Price: 40, Size: 10}, {Price: 38, Size: 5}},
+		NoAsks:  []BookLevel{{Price: 60, Size: 7}}, // -> YES bid at 40
+		YesAsks: []BookLevel{{Price: 44, Size: 3}},
+		NoBids:  []BookLevel{{Price: 56, Size: 9}}, // -> YES ask at 44
+	}
+
+	bids := depth.ConsolidatedBids()
+	assert.Equal(t, []BookLevel{{Price: 40, Size: 17}, {Price: 38, Size: 5}}, bids)
+	assert.Equal(t, 40*17.0+38*5.0, centShares(bids))
+
+	asks := depth.ConsolidatedAsks()
+	assert.Equal(t, []BookLevel{{Price: 44, Size: 12}}, asks)
+	assert.Equal(t, 44*12.0, centShares(asks))
+}
+
+func prices(levels []ConsolidatedLevel) []float64 {
+	out := make([]float64, 0, len(levels))
+	for _, l := range levels {
+		out = append(out, l.Price)
+	}
+	return out
+}
+
+func centShares(levels []BookLevel) float64 {
+	total := 0.0
+	for _, l := range levels {
+		total += l.Price * l.Size
+	}
+	return total
+}

--- a/core/forecast/forecast.go
+++ b/core/forecast/forecast.go
@@ -258,38 +258,20 @@ func round4(v float64) float64 { return math.Round(v*1e4) / 1e4 }
 // ConsolidatedBids returns the bucket's executable bid ladder: its YES bids plus
 // every NO ask inverted to the YES price it is hittable at, best (highest)
 // first.
+//
+// A native and an inverted level landing on the same price merge into one entry.
+// Everything downstream here sums price x size or walks the ladder in price
+// order, so merging leaves the forecast numbers unchanged. Callers that need the
+// native/inverse split should use ConsolidateSide directly.
 func (d BucketDepth) ConsolidatedBids() []BookLevel {
-	levels := make([]BookLevel, 0, len(d.YesBids)+len(d.NoAsks))
-	for _, l := range d.YesBids {
-		if l.Size > 0 {
-			levels = append(levels, l)
-		}
-	}
-	for _, l := range d.NoAsks {
-		if l.Size > 0 {
-			levels = append(levels, BookLevel{Price: round4(100 - l.Price), Size: l.Size})
-		}
-	}
-	sort.SliceStable(levels, func(i, j int) bool { return levels[i].Price > levels[j].Price })
-	return levels
+	return flatten(ConsolidateSide(d.YesBids, d.NoAsks, BidSide))
 }
 
 // ConsolidatedAsks returns the bucket's executable ask ladder: its YES asks plus
 // every NO bid inverted to the YES price it is hittable at, best (lowest) first.
+// Same-price levels merge, as in ConsolidatedBids.
 func (d BucketDepth) ConsolidatedAsks() []BookLevel {
-	levels := make([]BookLevel, 0, len(d.YesAsks)+len(d.NoBids))
-	for _, l := range d.YesAsks {
-		if l.Size > 0 {
-			levels = append(levels, l)
-		}
-	}
-	for _, l := range d.NoBids {
-		if l.Size > 0 {
-			levels = append(levels, BookLevel{Price: round4(100 - l.Price), Size: l.Size})
-		}
-	}
-	sort.SliceStable(levels, func(i, j int) bool { return levels[i].Price < levels[j].Price })
-	return levels
+	return flatten(ConsolidateSide(d.YesAsks, d.NoBids, AskSide))
 }
 
 // BestView returns the consolidated best quotes, for the spread and dutch-book

--- a/core/types/order_book_types.go
+++ b/core/types/order_book_types.go
@@ -117,6 +117,20 @@ type IOrderBook interface {
 	// Migration: 038-order-book-queries.sql:219-268
 	GetBestPrices(ctx context.Context, input GetBestPricesInput) (*BestPrices, error)
 
+	// GetConsolidatedOrderBook returns one outcome's book with the opposite
+	// outcome's quotes folded in, so the caller sees every quote the chain will
+	// actually fill.
+	//
+	// Composed of two get_market_depth calls rather than mapping to one action:
+	// a resting SELL NO at 93c is a hittable YES bid at 7c, and the engine fills
+	// it by burning the share pair.
+	//
+	// The result is NOT a sweepable ladder. Mint and burn fire only at the exact
+	// complement, so one order fills every native level past its limit plus
+	// exactly one inverse level.
+	GetConsolidatedOrderBook(ctx context.Context, input GetConsolidatedOrderBookInput) (
+		*forecast.ConsolidatedOrderBook, error)
+
 	// GetMarketForecast collapses a market's bucket books into the single value
 	// they imply: the median of the implied distribution, plus the band around it.
 	//
@@ -503,6 +517,21 @@ type GetMarketDepthInput struct {
 
 // Validate checks if GetMarketDepthInput is valid
 func (g *GetMarketDepthInput) Validate() error {
+	if g.QueryID < 1 {
+		return fmt.Errorf("query_id must be positive, got %d", g.QueryID)
+	}
+	return nil
+}
+
+// GetConsolidatedOrderBookInput contains parameters for getting a consolidated
+// order book
+type GetConsolidatedOrderBookInput struct {
+	QueryID int  // Market ID
+	Outcome bool // The outcome the prices are framed in: true=YES, false=NO
+}
+
+// Validate checks if GetConsolidatedOrderBookInput is valid
+func (g *GetConsolidatedOrderBookInput) Validate() error {
 	if g.QueryID < 1 {
 		return fmt.Errorf("query_id must be positive, got %d", g.QueryID)
 	}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1914,10 +1914,11 @@ type MarketData struct {
 
 `GetMarketDepth` returns one outcome's ladder, but a binary market's two books
 are two views of one position and the matching engine fills across them. A
-resting SELL NO at 93c is a standing offer that lets someone buy YES at 7c, and
-the chain will execute it. Read only the YES book and that quote is invisible.
+resting SELL NO at 93c is a standing **bid** for YES at 7c: a trader hits it by
+**selling** YES, both sides sell, and the chain burns the share pair. Read only
+the YES book and that quote is invisible.
 
-#### `OrderBook.GetConsolidatedOrderBook`
+### `OrderBook.GetConsolidatedOrderBook`
 
 Returns one outcome's book with the opposite outcome's quotes folded in.
 
@@ -1971,7 +1972,11 @@ a YES bid at 61 against a NO bid at 45 shows a bid at 61 over an ask at 55, and
 61 + 45 is not 100 so nothing matches. Render it rather than treating it as bad
 data.
 
-Costs two `get_market_depth` reads.
+Costs two `get_market_depth` reads. They are **not atomic**: `get_market_depth`
+takes only a query id and an outcome, and the transport exposes no block height,
+so there is no way to pin both sides to one snapshot. On a moving book the two
+sides can come from adjacent heights, which makes `IsCrossed` best-effort.
+Re-read before acting on it.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1910,6 +1910,71 @@ type MarketData struct {
 
 ---
 
+## Consolidated Order Books
+
+`GetMarketDepth` returns one outcome's ladder, but a binary market's two books
+are two views of one position and the matching engine fills across them. A
+resting SELL NO at 93c is a standing offer that lets someone buy YES at 7c, and
+the chain will execute it. Read only the YES book and that quote is invisible.
+
+#### `OrderBook.GetConsolidatedOrderBook`
+
+Returns one outcome's book with the opposite outcome's quotes folded in.
+
+**Signature:**
+```go
+func (o *OrderBook) GetConsolidatedOrderBook(
+    ctx context.Context, input types.GetConsolidatedOrderBookInput,
+) (*forecast.ConsolidatedOrderBook, error)
+```
+
+**Parameters:**
+- `input.QueryID` (int): the market to read.
+- `input.Outcome` (bool): the outcome to frame prices in, true=YES. The
+  NO-framed book is the YES-framed book reflected, so one call answers either
+  tab.
+
+In the YES frame:
+
+```text
+consolidated bids = YES bids + (100 - p for every NO ask)
+consolidated asks = YES asks + (100 - p for every NO bid)
+```
+
+The sides swap. A NO ask arrives as a YES bid, because hitting it means both
+parties sell and the share pair burns; hitting a consolidated ask means both buy
+and a pair mints.
+
+**Example:**
+```go
+book, err := orderBook.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
+    QueryID: 419, Outcome: true,
+})
+if err != nil {
+    return err
+}
+for _, level := range book.Asks {
+    fmt.Printf("%.0fc: %.0f shares (%.0f direct, %.0f mint)\n",
+        level.Price, level.Total, level.Native, level.Inverse)
+}
+```
+
+**This is not a sweepable ladder.** A direct same-outcome match crosses prices,
+but mint and burn fire only when the two prices sum to exactly 100. So one order
+fills every native level past its limit plus exactly **one** inverse level.
+Walking these levels the way you would walk `GetMarketDepth` quotes fills the
+chain will not produce, which is why each level keeps `Native` and `Inverse`
+separate rather than only their sum.
+
+A consolidated book can also sit crossed indefinitely, which `IsCrossed` reports:
+a YES bid at 61 against a NO bid at 45 shows a bid at 61 over an ask at 55, and
+61 + 45 is not 100 so nothing matches. Render it rather than treating it as bad
+data.
+
+Costs two `get_market_depth` reads.
+
+---
+
 ## Market Forecasting
 
 Prediction markets price **ranges**, not values. A five-bucket EPS market says

--- a/tests/integration/consolidated_order_book_test.go
+++ b/tests/integration/consolidated_order_book_test.go
@@ -24,6 +24,7 @@ package integration
 import (
 	"context"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,9 +36,15 @@ import (
 	"github.com/trufnetwork/sdk-go/core/types"
 )
 
-// maxMarketsProbed bounds discovery, which costs two calls per active market.
-// Mainnet carried ~130 active markets when this was written.
-const maxMarketsProbed = 200
+const (
+	// maxMarketsProbed bounds discovery, which costs two calls per active
+	// market. Mainnet carried ~130 active markets when this was written.
+	maxMarketsProbed = 200
+
+	// stableReadAttempts is how many times to re-read a market that moved
+	// underneath the comparison before giving up and skipping.
+	stableReadAttempts = 3
+)
 
 func TestConsolidatedOrderBookLive(t *testing.T) {
 	endpoint := os.Getenv("TN_LIVE_ENDPOINT")
@@ -63,15 +70,12 @@ func TestConsolidatedOrderBookLive(t *testing.T) {
 	}
 	t.Logf("reading market %d", queryID)
 
-	yesDepth, err := ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: true})
-	require.NoError(t, err)
-	noDepth, err := ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: false})
-	require.NoError(t, err)
+	yesDepth, noDepth, book, noBook, ok := readStableBooks(ctx, t, ob, queryID)
+	if !ok {
+		t.Skipf("market %d kept moving across %d attempts; nothing to compare against",
+			queryID, stableReadAttempts)
+	}
 
-	book, err := ob.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
-		QueryID: queryID, Outcome: true,
-	})
-	require.NoError(t, err)
 	require.NotNil(t, book)
 	assert.Equal(t, queryID, book.QueryID)
 	assert.True(t, book.Outcome)
@@ -92,14 +96,56 @@ func TestConsolidatedOrderBookLive(t *testing.T) {
 
 	// The NO-framed book is the YES-framed book reflected: price q becomes
 	// 100-q, bids become asks, and native volume becomes inverse volume.
-	noBook, err := ob.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
-		QueryID: queryID, Outcome: false,
-	})
-	require.NoError(t, err)
 	require.NotNil(t, noBook)
 	assert.False(t, noBook.Outcome)
 	assertReflects(t, book.Bids, noBook.Asks)
 	assertReflects(t, book.Asks, noBook.Bids)
+}
+
+// readStableBooks reads the raw depth and both framed books, and reports whether
+// the market held still while it did so.
+//
+// Every read here is a separate view call, and get_market_depth takes no block
+// height, so there is no snapshot to pin them to. On a live market an order can
+// land between two of them and the comparison would fail on drift rather than on
+// a real defect. Re-reading the raw depth afterwards and requiring it to match
+// closes that: if the book is unchanged either side of the sequence, the reads in
+// between saw the same state.
+func readStableBooks(ctx context.Context, t *testing.T, ob types.IOrderBook, queryID int) (
+	yesDepth, noDepth []types.DepthLevel,
+	book, noBook *forecast.ConsolidatedOrderBook,
+	ok bool,
+) {
+	t.Helper()
+
+	for attempt := 1; attempt <= stableReadAttempts; attempt++ {
+		var err error
+		yesDepth, err = ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: true})
+		require.NoError(t, err)
+		noDepth, err = ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: false})
+		require.NoError(t, err)
+
+		book, err = ob.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
+			QueryID: queryID, Outcome: true,
+		})
+		require.NoError(t, err)
+		noBook, err = ob.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
+			QueryID: queryID, Outcome: false,
+		})
+		require.NoError(t, err)
+
+		yesAfter, err := ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: true})
+		require.NoError(t, err)
+		noAfter, err := ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: false})
+		require.NoError(t, err)
+
+		if reflect.DeepEqual(yesDepth, yesAfter) && reflect.DeepEqual(noDepth, noAfter) {
+			return yesDepth, noDepth, book, noBook, true
+		}
+		t.Logf("market %d moved during attempt %d; re-reading", queryID, attempt)
+	}
+
+	return nil, nil, nil, nil, false
 }
 
 // checkSide verifies one consolidated side against the raw depth it came from.

--- a/tests/integration/consolidated_order_book_test.go
+++ b/tests/integration/consolidated_order_book_test.go
@@ -1,0 +1,230 @@
+// Live-network check that the SDK folds a market's two outcome books together
+// the right way round.
+//
+// The unit tests under core/forecast prove the mapping on hand-written numbers.
+// What they cannot prove is that the SDK reads the CHAIN correctly: if the node
+// flipped the sign convention on bids, or get_market_depth swapped its two
+// volume columns, every one of them would still pass while a NO ask surfaced on
+// the wrong side of the YES ladder. That is the gap this file covers.
+//
+// Gated on an env var rather than the kwiltest build tag, because it wants a
+// network carrying live markets with real orders rather than a fresh local node:
+//
+//	TN_LIVE_ENDPOINT=https://gateway.mainnet.truf.network \
+//	    go test ./tests/integration/ -run TestConsolidatedOrderBookLive -v
+//
+// All calls are view actions, so the signing key needs no funds and controls
+// nothing.
+//
+// These assert INVARIANTS against the raw depth reads, not numbers. Live books
+// move minute to minute, so pinning expected volumes would fail by tomorrow.
+
+package integration
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kwilcrypto "github.com/trufnetwork/kwil-db/core/crypto"
+	"github.com/trufnetwork/kwil-db/core/crypto/auth"
+	"github.com/trufnetwork/sdk-go/core/forecast"
+	"github.com/trufnetwork/sdk-go/core/tnclient"
+	"github.com/trufnetwork/sdk-go/core/types"
+)
+
+// maxMarketsProbed bounds discovery, which costs two calls per active market.
+// Mainnet carried ~130 active markets when this was written.
+const maxMarketsProbed = 200
+
+func TestConsolidatedOrderBookLive(t *testing.T) {
+	endpoint := os.Getenv("TN_LIVE_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("live network not configured; set TN_LIVE_ENDPOINT to run")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), liveTestTimeout)
+	defer cancel()
+
+	key, err := kwilcrypto.Secp256k1PrivateKeyFromHex(liveReadOnlyPK)
+	require.NoError(t, err, "failed to parse the read-only key")
+
+	client, err := tnclient.NewClient(ctx, endpoint, tnclient.WithSigner(auth.GetUserSigner(key)))
+	require.NoError(t, err, "failed to create client")
+
+	ob, err := client.LoadOrderBook()
+	require.NoError(t, err, "failed to load order book")
+
+	queryID, found := findQuotedMarket(ctx, t, ob)
+	if !found {
+		t.Skip("no active market on this network has any resting order")
+	}
+	t.Logf("reading market %d", queryID)
+
+	yesDepth, err := ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: true})
+	require.NoError(t, err)
+	noDepth, err := ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: false})
+	require.NoError(t, err)
+
+	book, err := ob.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
+		QueryID: queryID, Outcome: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, book)
+	assert.Equal(t, queryID, book.QueryID)
+	assert.True(t, book.Outcome)
+
+	// Bids are this outcome's buys plus the OTHER outcome's sells inverted; asks
+	// are this outcome's sells plus the other outcome's buys. Getting either
+	// pairing backwards is the failure this whole file exists to catch.
+	checkSide(t, "bids", book.Bids, buyVolumes(yesDepth), sellVolumes(noDepth), true)
+	checkSide(t, "asks", book.Asks, sellVolumes(yesDepth), buyVolumes(noDepth), false)
+
+	if book.IsCrossed {
+		require.NotEmpty(t, book.Bids)
+		require.NotEmpty(t, book.Asks)
+		assert.GreaterOrEqual(t, book.Bids[0].Price, book.Asks[0].Price)
+	} else if len(book.Bids) > 0 && len(book.Asks) > 0 {
+		assert.Less(t, book.Bids[0].Price, book.Asks[0].Price)
+	}
+
+	// The NO-framed book is the YES-framed book reflected: price q becomes
+	// 100-q, bids become asks, and native volume becomes inverse volume.
+	noBook, err := ob.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
+		QueryID: queryID, Outcome: false,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, noBook)
+	assert.False(t, noBook.Outcome)
+	assertReflects(t, book.Bids, noBook.Asks)
+	assertReflects(t, book.Asks, noBook.Bids)
+}
+
+// checkSide verifies one consolidated side against the raw depth it came from.
+//
+// native maps price to the volume resting in this outcome's own book; opposite
+// maps price to the volume resting in the other outcome's book, which belongs at
+// 100 minus that price.
+func checkSide(
+	t *testing.T,
+	name string,
+	levels []forecast.ConsolidatedLevel,
+	native, opposite map[float64]float64,
+	descending bool,
+) {
+	t.Helper()
+
+	seenNative := 0
+	seenOpposite := 0
+	for i, level := range levels {
+		assert.Greater(t, level.Price, 0.0, "%s[%d] price", name, i)
+		assert.Less(t, level.Price, 100.0, "%s[%d] price", name, i)
+		assert.Greater(t, level.Total, 0.0, "%s[%d] is an empty level", name, i)
+		assert.Equal(t, level.Native+level.Inverse, level.Total, "%s[%d] total", name, i)
+
+		assert.Equal(t, native[level.Price], level.Native, "%s at %v native", name, level.Price)
+		assert.Equal(t, opposite[100-level.Price], level.Inverse, "%s at %v inverse", name, level.Price)
+		if level.Native > 0 {
+			seenNative++
+		}
+		if level.Inverse > 0 {
+			seenOpposite++
+		}
+
+		if i > 0 && descending {
+			assert.Greater(t, levels[i-1].Price, level.Price, "%s must be best-highest first", name)
+		} else if i > 0 {
+			assert.Less(t, levels[i-1].Price, level.Price, "%s must be best-lowest first", name)
+		}
+	}
+
+	// Nothing on the chain may go missing on the way through.
+	assert.Equal(t, len(native), seenNative, "%s dropped a native level", name)
+	assert.Equal(t, len(opposite), seenOpposite, "%s dropped an inverse level", name)
+}
+
+// assertReflects checks that one frame's side is the other frame's opposite side
+// mirrored across 100.
+func assertReflects(t *testing.T, from, to []forecast.ConsolidatedLevel) {
+	t.Helper()
+
+	require.Len(t, to, len(from))
+	for i, level := range from {
+		assert.Equal(t, forecast.ConsolidatedLevel{
+			Price:   100 - level.Price,
+			Total:   level.Total,
+			Native:  level.Inverse,
+			Inverse: level.Native,
+		}, to[i])
+	}
+}
+
+// findQuotedMarket returns an active market carrying resting orders, preferring
+// one quoted on BOTH outcomes since that is what actually exercises the fold.
+func findQuotedMarket(ctx context.Context, t *testing.T, ob types.IOrderBook) (int, bool) {
+	t.Helper()
+
+	// FALSE means active only, per 032-order-book-actions.sql:358. Settled
+	// markets cannot move and would only waste probes.
+	active := false
+	offset, scanned := 0, 0
+	fallback, haveFallback := 0, false
+
+	for scanned < maxMarketsProbed {
+		limit := 100
+		page, err := ob.ListMarkets(ctx, types.ListMarketsInput{
+			SettledFilter: &active, Limit: &limit, Offset: &offset,
+		})
+		require.NoError(t, err)
+		if len(page) == 0 {
+			break
+		}
+
+		for _, summary := range page {
+			scanned++
+			yesQuoted := hasResting(ctx, ob, summary.ID, true)
+			noQuoted := hasResting(ctx, ob, summary.ID, false)
+			if yesQuoted && noQuoted {
+				return summary.ID, true
+			}
+			if (yesQuoted || noQuoted) && !haveFallback {
+				fallback, haveFallback = summary.ID, true
+			}
+		}
+
+		if len(page) < limit {
+			break
+		}
+		offset += limit
+	}
+
+	return fallback, haveFallback
+}
+
+// hasResting reports whether an outcome has any order resting on it.
+func hasResting(ctx context.Context, ob types.IOrderBook, queryID int, outcome bool) bool {
+	best, err := ob.GetBestPrices(ctx, types.GetBestPricesInput{QueryID: queryID, Outcome: outcome})
+	return err == nil && best != nil && (best.BestBid != nil || best.BestAsk != nil)
+}
+
+func buyVolumes(depth []types.DepthLevel) map[float64]float64 {
+	out := map[float64]float64{}
+	for _, level := range depth {
+		if level.BuyVolume > 0 {
+			out[float64(level.Price)] = float64(level.BuyVolume)
+		}
+	}
+	return out
+}
+
+func sellVolumes(depth []types.DepthLevel) map[float64]float64 {
+	out := map[float64]float64{}
+	for _, level := range depth {
+		if level.SellVolume > 0 {
+			out[float64(level.Price)] = float64(level.SellVolume)
+		}
+	}
+	return out
+}

--- a/tests/integration/order_book_test.go
+++ b/tests/integration/order_book_test.go
@@ -65,6 +65,13 @@ func TestOrderBookMarketValidation(t *testing.T) {
 
 // testCreateMarketValidation tests input validation
 func testCreateMarketValidation(t *testing.T, ctx context.Context, orderBook types.IOrderBook) {
+	// Markets are created from a bridge namespace plus the ABI-encoded query
+	// components, not from a precomputed hash. Validate only checks the encoding
+	// is long enough to be that tuple (address, bytes32, and the two offsets),
+	// so the content here does not matter.
+	validComponents := make([]byte, 128)
+	future := time.Now().Add(1 * time.Hour).Unix()
+
 	tests := []struct {
 		name    string
 		input   types.CreateMarketInput
@@ -74,42 +81,92 @@ func testCreateMarketValidation(t *testing.T, ctx context.Context, orderBook typ
 		{
 			name: "valid input",
 			input: types.CreateMarketInput{
-				QueryHash:    make([]byte, 32),
-				SettleTime:   time.Now().Add(1 * time.Hour).Unix(),
-				MaxSpread:    5,
-				MinOrderSize: 100,
+				Bridge:          "eth_truf",
+				QueryComponents: validComponents,
+				SettleTime:      future,
+				MaxSpread:       5,
+				MinOrderSize:    100,
 			},
 			wantErr: false,
 		},
 		{
-			name: "invalid hash length",
+			name: "missing bridge",
 			input: types.CreateMarketInput{
-				QueryHash:    make([]byte, 16),
-				SettleTime:   time.Now().Add(1 * time.Hour).Unix(),
+				QueryComponents: validComponents,
+				SettleTime:      future,
+				MaxSpread:       5,
+				MinOrderSize:    100,
+			},
+			wantErr: true,
+			errMsg:  "bridge is required",
+		},
+		{
+			name: "unknown bridge",
+			input: types.CreateMarketInput{
+				Bridge:          "eth_dai",
+				QueryComponents: validComponents,
+				SettleTime:      future,
+				MaxSpread:       5,
+				MinOrderSize:    100,
+			},
+			wantErr: true,
+			errMsg:  "bridge must be one of",
+		},
+		{
+			name: "missing query components",
+			input: types.CreateMarketInput{
+				Bridge:       "eth_truf",
+				SettleTime:   future,
 				MaxSpread:    5,
 				MinOrderSize: 100,
 			},
 			wantErr: true,
-			errMsg:  "must be exactly 32 bytes",
+			errMsg:  "query_components is required",
+		},
+		{
+			name: "query components too short for the ABI tuple",
+			input: types.CreateMarketInput{
+				Bridge:          "eth_truf",
+				QueryComponents: make([]byte, 127),
+				SettleTime:      future,
+				MaxSpread:       5,
+				MinOrderSize:    100,
+			},
+			wantErr: true,
+			errMsg:  "query_components too short",
 		},
 		{
 			name: "invalid settle time",
 			input: types.CreateMarketInput{
-				QueryHash:    make([]byte, 32),
-				SettleTime:   -1,
-				MaxSpread:    5,
-				MinOrderSize: 100,
+				Bridge:          "eth_truf",
+				QueryComponents: validComponents,
+				SettleTime:      -1,
+				MaxSpread:       5,
+				MinOrderSize:    100,
 			},
 			wantErr: true,
 			errMsg:  "settle_time must be positive",
 		},
 		{
+			name: "settle time already passed",
+			input: types.CreateMarketInput{
+				Bridge:          "eth_truf",
+				QueryComponents: validComponents,
+				SettleTime:      time.Now().Add(-1 * time.Hour).Unix(),
+				MaxSpread:       5,
+				MinOrderSize:    100,
+			},
+			wantErr: true,
+			errMsg:  "settle_time must be a future unix timestamp",
+		},
+		{
 			name: "invalid max spread (too low)",
 			input: types.CreateMarketInput{
-				QueryHash:    make([]byte, 32),
-				SettleTime:   time.Now().Add(1 * time.Hour).Unix(),
-				MaxSpread:    0,
-				MinOrderSize: 100,
+				Bridge:          "eth_truf",
+				QueryComponents: validComponents,
+				SettleTime:      future,
+				MaxSpread:       0,
+				MinOrderSize:    100,
 			},
 			wantErr: true,
 			errMsg:  "max_spread must be between 1 and 50",
@@ -117,10 +174,11 @@ func testCreateMarketValidation(t *testing.T, ctx context.Context, orderBook typ
 		{
 			name: "invalid max spread (too high)",
 			input: types.CreateMarketInput{
-				QueryHash:    make([]byte, 32),
-				SettleTime:   time.Now().Add(1 * time.Hour).Unix(),
-				MaxSpread:    51,
-				MinOrderSize: 100,
+				Bridge:          "eth_truf",
+				QueryComponents: validComponents,
+				SettleTime:      future,
+				MaxSpread:       51,
+				MinOrderSize:    100,
 			},
 			wantErr: true,
 			errMsg:  "max_spread must be between 1 and 50",
@@ -128,10 +186,11 @@ func testCreateMarketValidation(t *testing.T, ctx context.Context, orderBook typ
 		{
 			name: "invalid min order size",
 			input: types.CreateMarketInput{
-				QueryHash:    make([]byte, 32),
-				SettleTime:   time.Now().Add(1 * time.Hour).Unix(),
-				MaxSpread:    5,
-				MinOrderSize: 0,
+				Bridge:          "eth_truf",
+				QueryComponents: validComponents,
+				SettleTime:      future,
+				MaxSpread:       5,
+				MinOrderSize:    0,
 			},
 			wantErr: true,
 			errMsg:  "min_order_size must be positive",


### PR DESCRIPTION
`GetMarketDepth` returns one outcome's ladder, but a binary market's two books are two views of one position and the matching engine fills across them. A resting SELL NO at 93c is a standing **bid** for YES at 7c: a trader hits it by **selling** YES, both sides sell, and the chain burns the share pair. Read only the YES book and that quote is invisible, so the market reads thinner and worse-priced than it is.

`OrderBook.GetConsolidatedOrderBook` folds them together, in the YES frame:

```
consolidated bids = YES bids + (100 - p for every NO ask)
consolidated asks = YES asks + (100 - p for every NO bid)
```

The sides swap. A NO ask arrives as a YES bid, because hitting it means both parties sell and the pair burns; hitting a consolidated ask means both buy and a pair mints.

```go
book, err := orderBook.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
    QueryID: 419, Outcome: true,
})
for _, level := range book.Asks {
    fmt.Printf("%.0fc: %.0f (%.0f direct, %.0f mint)\n",
        level.Price, level.Total, level.Native, level.Inverse)
}
```

## This is not a sweepable ladder

A direct same-outcome match crosses prices. `match_mint` and `match_burn` fire only when the two prices sum to exactly 100: they return early otherwise, and select the resting order with `price =` rather than a range. So one order fills every native level past its limit plus exactly **one** inverse level.

Walking these levels the way you would walk `GetMarketDepth` quotes fills the chain will not produce. That is why each level keeps `Native` and `Inverse` separately instead of only their sum, so a caller can price the fill correctly.

A consolidated book can also sit crossed indefinitely, which `IsCrossed` reports. A YES bid at 61 against a NO bid at 45 shows a bid at 61 over an ask at 55, and 61 + 45 is not 100, so nothing matches and the crossing rests until someone reprices.

## What changed

- `core/forecast/consolidated.go`, new: the mapping itself, as `ConsolidateSide`, `InversePrice`, `Crossed`, plus `ConsolidatedLevel` and `ConsolidatedOrderBook`.
- `GetConsolidatedOrderBook` in `core/contractsapi/order_book_queries.go`, added to `IOrderBook` with `GetConsolidatedOrderBookInput`. It returns `*forecast.ConsolidatedOrderBook`, matching how `GetMarketForecast` already returns a forecast type: `core/types` imports `core/forecast`, so these types cannot live in `core/types`.
- `BucketDepth.ConsolidatedBids` / `ConsolidatedAsks` now call the shared helper rather than carrying their own copy of the inversion. They merge same-price levels as a result; the forecast only sums `price x size` or walks the ladder in price order, so its numbers are unchanged, and there is a test asserting exactly that.
- `docs/api-reference.md`.

Mirrors the sdk-js side:

- <https://github.com/trufnetwork/sdk-js/pull/174>

## Testing

9 unit tests in `core/forecast/consolidated_test.go`, including the case from the linked issue verbatim (a NO ask for 4 shares at 93 surfacing as a YES bid for 4 at 7), the same-price merge keeping its split, the NO frame reflecting the YES frame, and the crossed book.

`tests/integration/consolidated_order_book_test.go` is a live read gated on `TN_LIVE_ENDPOINT`, following `market_forecast_test.go`. It finds an active market quoted on both outcomes and checks the consolidated book against the raw depth reads: sides, native/inverse split, sort order, nothing dropped, and the NO frame reflecting the YES frame. All view actions, so the key needs no funds. The unit tests prove the arithmetic; this proves the SDK reads the chain the right way round, which is the failure that would otherwise pass every unit test silently.

```
TN_LIVE_ENDPOINT=https://gateway.mainnet.truf.network \
    go test ./tests/integration/ -run TestConsolidatedOrderBookLive -v
```

resolves: https://github.com/truflation/website/issues/4388


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consolidated order-book views for binary markets, combining direct and inverse-outcome liquidity.
  * Added support for YES/NO price framing, merged price levels, volume breakdowns, and crossed-book detection.
  * Added validation for consolidated order-book queries.

* **Documentation**
  * Documented the consolidated order-book API, price transformations, matching behavior, and usage examples.

* **Bug Fixes**
  * Improved order-book consolidation to exclude empty levels and preserve correct execution ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
