### PR TITLE
feat: read a consolidated book from a single chain read

### DIFF
--- a/core/contractsapi/order_book_full_depth_test.go
+++ b/core/contractsapi/order_book_full_depth_test.go
@@ -1,0 +1,88 @@
+package contractsapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trufnetwork/sdk-go/core/types"
+)
+
+// get_full_market_depth returns both outcomes' ladders in one result set, tagged
+// with the outcome each level rests on. Everything between that result set and a
+// consolidated book is parsing and a split, so both are testable without a node.
+//
+// The split is where a mistake would be invisible: putting the requested
+// outcome's levels on the opposite pile still produces a plausible-looking book,
+// with every quote on the wrong side of the ladder.
+
+func TestParseFullDepthLevelRow(t *testing.T) {
+	t.Run("reads the four columns in the order the action returns them", func(t *testing.T) {
+		level, err := parseFullDepthLevelRow([]any{true, int64(55), int64(150), int64(0)})
+
+		require.NoError(t, err)
+		assert.Equal(t, types.FullDepthLevel{
+			Outcome: true, Price: 55, BuyVolume: 150, SellVolume: 0,
+		}, level)
+	})
+
+	t.Run("keeps a NO level tagged NO", func(t *testing.T) {
+		level, err := parseFullDepthLevelRow([]any{false, int64(40), int64(0), int64(100)})
+
+		require.NoError(t, err)
+		assert.Equal(t, types.FullDepthLevel{
+			Outcome: false, Price: 40, BuyVolume: 0, SellVolume: 100,
+		}, level)
+	})
+
+	t.Run("accepts the string volumes the gateway can send", func(t *testing.T) {
+		level, err := parseFullDepthLevelRow([]any{true, "55", "150", "25"})
+
+		require.NoError(t, err)
+		assert.Equal(t, types.FullDepthLevel{
+			Outcome: true, Price: 55, BuyVolume: 150, SellVolume: 25,
+		}, level)
+	})
+
+	t.Run("rejects a row that is missing a column", func(t *testing.T) {
+		_, err := parseFullDepthLevelRow([]any{true, int64(55), int64(150)})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected 4 columns")
+	})
+}
+
+func TestSplitFullDepth(t *testing.T) {
+	depth := []types.FullDepthLevel{
+		{Outcome: true, Price: 55, BuyVolume: 150},
+		{Outcome: false, Price: 30, BuyVolume: 200},
+		{Outcome: false, Price: 40, SellVolume: 100},
+	}
+
+	t.Run("in the YES frame the NO levels are the opposite ladder", func(t *testing.T) {
+		native, opposite := splitFullDepth(depth, true)
+
+		assert.Equal(t, []types.DepthLevel{{Price: 55, BuyVolume: 150}}, native)
+		assert.Equal(t, []types.DepthLevel{
+			{Price: 30, BuyVolume: 200},
+			{Price: 40, SellVolume: 100},
+		}, opposite)
+	})
+
+	t.Run("in the NO frame the two piles swap", func(t *testing.T) {
+		native, opposite := splitFullDepth(depth, false)
+
+		assert.Equal(t, []types.DepthLevel{
+			{Price: 30, BuyVolume: 200},
+			{Price: 40, SellVolume: 100},
+		}, native)
+		assert.Equal(t, []types.DepthLevel{{Price: 55, BuyVolume: 150}}, opposite)
+	})
+
+	t.Run("an outcome quoted on neither side yields two empty ladders", func(t *testing.T) {
+		native, opposite := splitFullDepth(nil, true)
+
+		assert.Empty(t, native)
+		assert.Empty(t, opposite)
+	})
+}

--- a/core/contractsapi/order_book_queries.go
+++ b/core/contractsapi/order_book_queries.go
@@ -95,6 +95,42 @@ func (o *OrderBook) GetMarketDepth(ctx context.Context, input types.GetMarketDep
 	return levels, nil
 }
 
+// GetFullMarketDepth returns aggregated volume per price level for both outcomes
+// Maps to: get_full_market_depth($query_id)
+// Migration: 038-order-book-queries.sql:215-282
+//
+// Same aggregation as GetMarketDepth, for the whole market instead of one
+// outcome, with each level tagged by the outcome it rests on. Rows arrive YES
+// first then NO, price ascending within each.
+//
+// One statement means one snapshot. Anything that compares the two outcomes to
+// each other wants this rather than two GetMarketDepth calls, because between
+// two calls an order can land on one side and not the other.
+func (o *OrderBook) GetFullMarketDepth(
+	ctx context.Context, input types.GetFullMarketDepthInput,
+) ([]types.FullDepthLevel, error) {
+	if err := input.Validate(); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	args := []any{input.QueryID}
+	result, err := o.call(ctx, "get_full_market_depth", args)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var levels []types.FullDepthLevel
+	for _, row := range result.Values {
+		level, err := parseFullDepthLevelRow(row)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		levels = append(levels, level)
+	}
+
+	return levels, nil
+}
+
 // GetBestPrices returns current bid/ask spread
 // Maps to: get_best_prices($query_id, $outcome)
 // Migration: 038-order-book-queries.sql:219-268
@@ -131,13 +167,13 @@ func (o *OrderBook) GetBestPrices(ctx context.Context, input types.GetBestPrices
 // GetConsolidatedOrderBook returns one outcome's book with the opposite
 // outcome's quotes folded in.
 //
-// Composed of two get_market_depth calls rather than mapping to one action.
-// GetMarketDepth returns a single outcome's ladder, but a binary market's two
-// books are two views of one position and the matching engine fills across them.
-// A resting SELL NO at 93c is a standing BID for YES at 7c: a trader hits it by
-// SELLING YES, both sides sell, and the chain burns the share pair. Reading only
-// the YES book makes that quote invisible and the market look thinner than it
-// is.
+// Reads the whole market with one get_full_market_depth call and folds the two
+// sides together here. GetMarketDepth returns a single outcome's ladder, but a
+// binary market's two books are two views of one position and the matching
+// engine fills across them. A resting SELL NO at 93c is a standing BID for YES
+// at 7c: a trader hits it by SELLING YES, both sides sell, and the chain burns
+// the share pair. Reading only the YES book makes that quote invisible and the
+// market look thinner than it is.
 //
 // So, in the YES frame:
 //
@@ -158,12 +194,12 @@ func (o *OrderBook) GetBestPrices(ctx context.Context, input types.GetBestPrices
 // Input.Outcome frames the prices. The NO-framed book is the YES-framed book
 // reflected, so one call answers either tab.
 //
-// The two depth reads are NOT atomic. get_market_depth takes only a query_id and
-// an outcome (038-order-book-queries.sql:182) and the transport exposes no block
-// height, so there is no way to pin both sides to one snapshot from here. On a
-// moving book the two sides can come from adjacent heights, which makes
-// IsCrossed best-effort: re-read before acting on it. Closing the window would
-// take a node action returning both outcomes' depth in one call.
+// Both sides come from one read, so they are one snapshot of the chain and
+// IsCrossed describes a state the book was really in. This used to take two
+// get_market_depth calls, where an order landing between them could make the
+// stitched ladder read as crossed when neither height was.
+//
+// Requires a node carrying get_full_market_depth.
 func (o *OrderBook) GetConsolidatedOrderBook(
 	ctx context.Context, input types.GetConsolidatedOrderBookInput,
 ) (*forecast.ConsolidatedOrderBook, error) {
@@ -171,18 +207,11 @@ func (o *OrderBook) GetConsolidatedOrderBook(
 		return nil, errors.WithStack(err)
 	}
 
-	native, err := o.GetMarketDepth(ctx, types.GetMarketDepthInput{
-		QueryID: input.QueryID, Outcome: input.Outcome,
-	})
+	depth, err := o.GetFullMarketDepth(ctx, types.GetFullMarketDepthInput{QueryID: input.QueryID})
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	opposite, err := o.GetMarketDepth(ctx, types.GetMarketDepthInput{
-		QueryID: input.QueryID, Outcome: !input.Outcome,
-	})
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
+	native, opposite := splitFullDepth(depth, input.Outcome)
 
 	bids := forecast.ConsolidateSide(depthBids(native), depthAsks(opposite), forecast.BidSide)
 	asks := forecast.ConsolidateSide(depthAsks(native), depthBids(opposite), forecast.AskSide)
@@ -194,6 +223,26 @@ func (o *OrderBook) GetConsolidatedOrderBook(
 		Asks:      asks,
 		IsCrossed: forecast.Crossed(bids, asks),
 	}, nil
+}
+
+// splitFullDepth separates a whole-market depth read into the ladder for the
+// requested outcome and the ladder for the other one.
+//
+// The outcome tag is the only thing that distinguishes the two here: prices are
+// still in each outcome's own frame, and inverting the opposite side into this
+// frame is ConsolidateSide's job.
+func splitFullDepth(depth []types.FullDepthLevel, outcome bool) (native, opposite []types.DepthLevel) {
+	for _, full := range depth {
+		level := types.DepthLevel{
+			Price: full.Price, BuyVolume: full.BuyVolume, SellVolume: full.SellVolume,
+		}
+		if full.Outcome == outcome {
+			native = append(native, level)
+		} else {
+			opposite = append(opposite, level)
+		}
+	}
+	return native, opposite
 }
 
 // depthBids returns the buy orders in a depth ladder, as levels.
@@ -420,6 +469,38 @@ func parseDepthLevelRow(row []any) (types.DepthLevel, error) {
 
 	// Column 2: sell_volume (INT8)
 	if err := extractInt64Column(row[2], &level.SellVolume, 2, "sell_volume"); err != nil {
+		return level, err
+	}
+
+	return level, nil
+}
+
+// parseFullDepthLevelRow parses a row from get_full_market_depth
+// Row format: outcome, price, buy_volume, sell_volume
+func parseFullDepthLevelRow(row []any) (types.FullDepthLevel, error) {
+	if len(row) < 4 {
+		return types.FullDepthLevel{}, fmt.Errorf("invalid row: expected 4 columns, got %d", len(row))
+	}
+
+	level := types.FullDepthLevel{}
+
+	// Column 0: outcome (BOOL)
+	if err := extractBoolColumn(row[0], &level.Outcome, 0, "outcome"); err != nil {
+		return level, err
+	}
+
+	// Column 1: price (INT)
+	if err := extractIntColumn(row[1], &level.Price, 1, "price"); err != nil {
+		return level, err
+	}
+
+	// Column 2: buy_volume (INT8)
+	if err := extractInt64Column(row[2], &level.BuyVolume, 2, "buy_volume"); err != nil {
+		return level, err
+	}
+
+	// Column 3: sell_volume (INT8)
+	if err := extractInt64Column(row[3], &level.SellVolume, 3, "sell_volume"); err != nil {
 		return level, err
 	}
 

--- a/core/types/order_book_types.go
+++ b/core/types/order_book_types.go
@@ -112,6 +112,16 @@ type IOrderBook interface {
 	// Migration: 038-order-book-queries.sql:149-208
 	GetMarketDepth(ctx context.Context, input GetMarketDepthInput) ([]DepthLevel, error)
 
+	// GetFullMarketDepth returns aggregated volume per price level for BOTH
+	// outcomes, from one read, tagged with the outcome each level belongs to.
+	// Maps to: get_full_market_depth($query_id)
+	// Migration: 038-order-book-queries.sql:215-282
+	//
+	// Use this over two GetMarketDepth calls whenever the two sides are compared
+	// to each other: one statement is one snapshot, so nothing can land between
+	// the sides.
+	GetFullMarketDepth(ctx context.Context, input GetFullMarketDepthInput) ([]FullDepthLevel, error)
+
 	// GetBestPrices returns current bid/ask spread
 	// Maps to: get_best_prices($query_id, $outcome)
 	// Migration: 038-order-book-queries.sql:219-268
@@ -121,9 +131,9 @@ type IOrderBook interface {
 	// outcome's quotes folded in, so the caller sees every quote the chain will
 	// actually fill.
 	//
-	// Composed of two get_market_depth calls rather than mapping to one action:
-	// a resting SELL NO at 93c is a hittable YES bid at 7c, and the engine fills
-	// it by burning the share pair.
+	// Reads both outcomes with one get_full_market_depth call and folds them
+	// here: a resting SELL NO at 93c is a hittable YES bid at 7c, and the engine
+	// fills it by burning the share pair.
 	//
 	// The result is NOT a sweepable ladder. Mint and burn fire only at the exact
 	// complement, so one order fills every native level past its limit plus
@@ -523,6 +533,20 @@ func (g *GetMarketDepthInput) Validate() error {
 	return nil
 }
 
+// GetFullMarketDepthInput contains parameters for getting both outcomes' market
+// depth in one read
+type GetFullMarketDepthInput struct {
+	QueryID int // Market ID
+}
+
+// Validate checks if GetFullMarketDepthInput is valid
+func (g *GetFullMarketDepthInput) Validate() error {
+	if g.QueryID < 1 {
+		return fmt.Errorf("query_id must be positive, got %d", g.QueryID)
+	}
+	return nil
+}
+
 // GetConsolidatedOrderBookInput contains parameters for getting a consolidated
 // order book
 type GetConsolidatedOrderBookInput struct {
@@ -790,6 +814,16 @@ type DepthLevel struct {
 	Price      int   // Price level (INT)
 	BuyVolume  int64 // Total buy volume at this price (INT8)
 	SellVolume int64 // Total sell volume at this price (INT8)
+}
+
+// FullDepthLevel represents aggregated volume at one outcome's price level, as
+// get_full_market_depth returns it. The outcome tag is what a DepthLevel leaves
+// implicit, because the call it comes from asked for one outcome.
+type FullDepthLevel struct {
+	Outcome    bool  // TRUE=YES, FALSE=NO (BOOL)
+	Price      int   // Price level (INT)
+	BuyVolume  int64 // Total buy volume at this outcome and price (INT8)
+	SellVolume int64 // Total sell volume at this outcome and price (INT8)
 }
 
 // BestPrices contains the current bid/ask spread

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1918,6 +1918,46 @@ resting SELL NO at 93c is a standing **bid** for YES at 7c: a trader hits it by
 **selling** YES, both sides sell, and the chain burns the share pair. Read only
 the YES book and that quote is invisible.
 
+### `OrderBook.GetFullMarketDepth`
+
+Returns aggregated volume per price level for **both** outcomes, from one read.
+
+**Signature:**
+```go
+func (o *OrderBook) GetFullMarketDepth(
+    ctx context.Context, input types.GetFullMarketDepthInput,
+) ([]types.FullDepthLevel, error)
+```
+
+**Parameters:**
+- `input.QueryID` (int): the market to read.
+
+Same aggregation as `GetMarketDepth`, for the whole market instead of one
+outcome, with each level tagged by the outcome it rests on. Rows arrive YES first
+then NO, price ascending within each.
+
+One statement means one snapshot. Anything comparing the two outcomes to each
+other wants this rather than two `GetMarketDepth` calls, because between two
+calls an order can land on one side and not the other.
+
+**Example:**
+```go
+depth, err := orderBook.GetFullMarketDepth(ctx, types.GetFullMarketDepthInput{QueryID: 419})
+if err != nil {
+    return err
+}
+for _, level := range depth {
+    side := "NO"
+    if level.Outcome {
+        side = "YES"
+    }
+    fmt.Printf("%s %dc: %d buy, %d sell\n", side, level.Price, level.BuyVolume, level.SellVolume)
+}
+```
+
+`GetMarketDepth` is unchanged and stays the right call when you want one
+outcome — a depth chart, a market-making bot quoting one side.
+
 ### `OrderBook.GetConsolidatedOrderBook`
 
 Returns one outcome's book with the opposite outcome's quotes folded in.
@@ -1972,11 +2012,11 @@ a YES bid at 61 against a NO bid at 45 shows a bid at 61 over an ask at 55, and
 61 + 45 is not 100 so nothing matches. Render it rather than treating it as bad
 data.
 
-Costs two `get_market_depth` reads. They are **not atomic**: `get_market_depth`
-takes only a query id and an outcome, and the transport exposes no block height,
-so there is no way to pin both sides to one snapshot. On a moving book the two
-sides can come from adjacent heights, which makes `IsCrossed` best-effort.
-Re-read before acting on it.
+Costs one `get_full_market_depth` read, so both sides are one snapshot of the
+chain and `IsCrossed` describes a state the book was really in. This used to take
+two `get_market_depth` calls, where an order landing between them could make the
+stitched ladder read as crossed when neither height was. Requires a node carrying
+`get_full_market_depth`.
 
 ---
 

--- a/tests/integration/consolidated_order_book_test.go
+++ b/tests/integration/consolidated_order_book_test.go
@@ -3,15 +3,18 @@
 //
 // The unit tests under core/forecast prove the mapping on hand-written numbers.
 // What they cannot prove is that the SDK reads the CHAIN correctly: if the node
-// flipped the sign convention on bids, or get_market_depth swapped its two
-// volume columns, every one of them would still pass while a NO ask surfaced on
-// the wrong side of the YES ladder. That is the gap this file covers.
+// flipped the sign convention on bids, or get_full_market_depth swapped its two
+// volume columns or its outcome tag, every one of them would still pass while a
+// NO ask surfaced on the wrong side of the YES ladder. That is the gap this file
+// covers.
 //
 // Gated on an env var rather than the kwiltest build tag, because it wants a
 // network carrying live markets with real orders rather than a fresh local node:
 //
 //	TN_LIVE_ENDPOINT=https://gateway.mainnet.truf.network \
 //	    go test ./tests/integration/ -run TestConsolidatedOrderBookLive -v
+//
+// The network must be running a node that carries get_full_market_depth.
 //
 // All calls are view actions, so the signing key needs no funds and controls
 // nothing.
@@ -70,7 +73,7 @@ func TestConsolidatedOrderBookLive(t *testing.T) {
 	}
 	t.Logf("reading market %d", queryID)
 
-	yesDepth, noDepth, book, noBook, ok := readStableBooks(ctx, t, ob, queryID)
+	depth, book, noBook, ok := readStableBooks(ctx, t, ob, queryID)
 	if !ok {
 		t.Skipf("market %d kept moving across %d attempts; nothing to compare against",
 			queryID, stableReadAttempts)
@@ -83,8 +86,8 @@ func TestConsolidatedOrderBookLive(t *testing.T) {
 	// Bids are this outcome's buys plus the OTHER outcome's sells inverted; asks
 	// are this outcome's sells plus the other outcome's buys. Getting either
 	// pairing backwards is the failure this whole file exists to catch.
-	checkSide(t, "bids", book.Bids, buyVolumes(yesDepth), sellVolumes(noDepth), true)
-	checkSide(t, "asks", book.Asks, sellVolumes(yesDepth), buyVolumes(noDepth), false)
+	checkSide(t, "bids", book.Bids, buyVolumes(depth, true), sellVolumes(depth, false), true)
+	checkSide(t, "asks", book.Asks, sellVolumes(depth, true), buyVolumes(depth, false), false)
 
 	if book.IsCrossed {
 		require.NotEmpty(t, book.Bids)
@@ -105,14 +108,15 @@ func TestConsolidatedOrderBookLive(t *testing.T) {
 // readStableBooks reads the raw depth and both framed books, and reports whether
 // the market held still while it did so.
 //
-// Every read here is a separate view call, and get_market_depth takes no block
-// height, so there is no snapshot to pin them to. On a live market an order can
-// land between two of them and the comparison would fail on drift rather than on
-// a real defect. Re-reading the raw depth afterwards and requiring it to match
-// closes that: if the book is unchanged either side of the sequence, the reads in
-// between saw the same state.
+// Each of those is its own view call. A consolidated book is now internally
+// consistent — it comes from one get_full_market_depth read — but comparing one
+// against another read is still comparing two points in time, and on a live
+// market an order can land in between. The comparison would then fail on drift
+// rather than on a real defect. Re-reading the raw depth afterwards and requiring
+// it to match closes that: if the book is unchanged either side of the sequence,
+// the reads in between saw the same state.
 func readStableBooks(ctx context.Context, t *testing.T, ob types.IOrderBook, queryID int) (
-	yesDepth, noDepth []types.DepthLevel,
+	depth []types.FullDepthLevel,
 	book, noBook *forecast.ConsolidatedOrderBook,
 	ok bool,
 ) {
@@ -120,10 +124,8 @@ func readStableBooks(ctx context.Context, t *testing.T, ob types.IOrderBook, que
 
 	for attempt := 1; attempt <= stableReadAttempts; attempt++ {
 		var err error
-		yesDepth, err = ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: true})
-		require.NoError(t, err)
-		noDepth, err = ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: false})
-		require.NoError(t, err)
+		depth, err = ob.GetFullMarketDepth(ctx, types.GetFullMarketDepthInput{QueryID: queryID})
+		require.NoError(t, err, "the network must carry get_full_market_depth")
 
 		book, err = ob.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
 			QueryID: queryID, Outcome: true,
@@ -134,18 +136,16 @@ func readStableBooks(ctx context.Context, t *testing.T, ob types.IOrderBook, que
 		})
 		require.NoError(t, err)
 
-		yesAfter, err := ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: true})
-		require.NoError(t, err)
-		noAfter, err := ob.GetMarketDepth(ctx, types.GetMarketDepthInput{QueryID: queryID, Outcome: false})
+		after, err := ob.GetFullMarketDepth(ctx, types.GetFullMarketDepthInput{QueryID: queryID})
 		require.NoError(t, err)
 
-		if reflect.DeepEqual(yesDepth, yesAfter) && reflect.DeepEqual(noDepth, noAfter) {
-			return yesDepth, noDepth, book, noBook, true
+		if reflect.DeepEqual(depth, after) {
+			return depth, book, noBook, true
 		}
 		t.Logf("market %d moved during attempt %d; re-reading", queryID, attempt)
 	}
 
-	return nil, nil, nil, nil, false
+	return nil, nil, nil, false
 }
 
 // checkSide verifies one consolidated side against the raw depth it came from.
@@ -255,20 +255,24 @@ func hasResting(ctx context.Context, ob types.IOrderBook, queryID int, outcome b
 	return err == nil && best != nil && (best.BestBid != nil || best.BestAsk != nil)
 }
 
-func buyVolumes(depth []types.DepthLevel) map[float64]float64 {
+// buyVolumes maps price to resting buy volume for one outcome of a whole-market
+// depth read.
+func buyVolumes(depth []types.FullDepthLevel, outcome bool) map[float64]float64 {
 	out := map[float64]float64{}
 	for _, level := range depth {
-		if level.BuyVolume > 0 {
+		if level.Outcome == outcome && level.BuyVolume > 0 {
 			out[float64(level.Price)] = float64(level.BuyVolume)
 		}
 	}
 	return out
 }
 
-func sellVolumes(depth []types.DepthLevel) map[float64]float64 {
+// sellVolumes maps price to resting sell volume for one outcome of a whole-market
+// depth read.
+func sellVolumes(depth []types.FullDepthLevel, outcome bool) map[float64]float64 {
 	out := map[float64]float64{}
 	for _, level := range depth {
-		if level.SellVolume > 0 {
+		if level.Outcome == outcome && level.SellVolume > 0 {
 			out[float64(level.Price)] = float64(level.SellVolume)
 		}
 	}


### PR DESCRIPTION
`GetConsolidatedOrderBook` now reads the whole market with one
`get_full_market_depth` call instead of one `GetMarketDepth` call per outcome, so
the two sides of the ladder describe the same moment.

## Why

A consolidated ladder only means anything if both sides come from the same state
of the chain. Reading YES and NO separately reads them at two independent points
in time, and an order landing between the two appears on one side and not the
other. The stitched ladder can then show a bid above an ask that never existed at
any single moment — which is why `IsCrossed` shipped documented as best-effort.

The node now answers the whole book in one statement, so that whole class of
artifact goes away.

## What is in it

- `GetFullMarketDepth`, mapping to the node's `get_full_market_depth`, plus
  `FullDepthLevel` and its input type. Same aggregation as `GetMarketDepth`, for
  both outcomes, each level tagged with the outcome it rests on.
- `splitFullDepth` separates that read back into the requested outcome's ladder
  and the other one's. The inversion into one frame is still `ConsolidateSide`'s
  job and is untouched.
- `GetConsolidatedOrderBook` calls the new read and splits, instead of two depth
  calls. Return shape is unchanged, so nothing downstream needs an edit.
- The not-atomic caveat is gone from the doc comments, the `IOrderBook` interface
  and `docs/api-reference.md`, because it is no longer true.
- Unit tests for the row parse and the split. The split is where a mistake would
  be invisible: putting the requested outcome's levels on the opposite pile still
  produces a plausible-looking book, with every quote on the wrong side.
- The live test reads its baseline from `GetFullMarketDepth` rather than two
  `GetMarketDepth` calls.

## What is not in it

`GetMarketDepth` is untouched and stays the right call for one outcome — a depth
chart, or a bot quoting one side.

The live test keeps its re-read guard. A consolidated book is now internally
consistent, but the test still compares it against a separate raw read, and on a
live market an order can land between the two; without the guard it would fail on
drift rather than on a defect. What the guard covers has changed, and its comment
now says so.

A fallback to the old two-read path when the node does not carry the action was
considered and dropped. It would make `IsCrossed` atomic sometimes and not
others, with no way for a caller to tell which they got — which is the ambiguity
this PR exists to remove.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./core/...`, all clean.

`IOrderBook` gains a method, so anything implementing that interface outside this
repo needs the addition. Nothing in-tree does beyond `OrderBook` itself.

The mapping is arithmetic and covered by unit tests. What no unit test can cover
is that the SDK reads the chain the right way round — that is
`TestConsolidatedOrderBookLive`, which needs `TN_LIVE_ENDPOINT` pointed at a
network carrying the action, and no network carries it yet.

## Before tagging a release

The latest node release is v2.5.5, from before the action merged, so no network
serves `get_full_market_depth` yet. Merging is fine; tagging a release that calls
it is not, until a node release carrying it is out and rolled to the networks
consumers read from.

## Follow-ups

`GetMarketForecast` still reads each bucket's two books separately and could move
to the new read, but it consumes individual orders from `GetOrderBook` rather
than aggregated depth, so that is its own change with its own review.

The same change lands in sdk-js alongside this one; sdk-py follows from here.

This is one of two SDK pull requests closing that Problem — sdk-js carries the
same change. Whichever merges first will close it, so reopen it until the other
one lands.

resolves: https://github.com/truflation/website/issues/4445


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-market-depth query that retrieves YES and NO order book levels in a single snapshot.
  * Added outcome-tagged depth data with price, buy volume, and sell volume details.
  * Updated consolidated order books to use the combined depth snapshot for improved consistency.

* **Documentation**
  * Documented the new full-depth query, response ordering, and node support requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->